### PR TITLE
Update order of @import and @layer

### DIFF
--- a/src/css/luis.css
+++ b/src/css/luis.css
@@ -1,7 +1,7 @@
-@layer reset, theme, layout, utilities, components;
-
 @import "_reset.css" layer(reset);
 @import "_theme.css" layer(theme);
 @import "_layout.css" layer(layout);
 @import "_utilities.css" layer(utilities);
 @import "_components.css" layer(components);
+
+@layer reset, theme, layout, utilities, components;


### PR DESCRIPTION
Safari really follows the W3C guidelines on this. The `@import` at-rule must be defined at the top of the stylesheet, before any other at-rule (except [@charset](https://developer.mozilla.org/en-US/docs/Web/CSS/@charset) and [@layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer)) and style declarations, or it will be ignored.

Along with this comment in MDN, means my imports need to happen before i set the order of the layers.

```
Imported rules must come before all other types of rules, except [@charset](https://developer.mozilla.org/en-US/docs/Web/CSS/@charset) rules and layer creating [@layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) statements.
```