### PR TITLE
Clean up codebase: fix broken links, remove dead code, modernize CSS

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-projectluis.com
+theluistorres.com

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <!-- Mobile Specific Metas -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <meta name="description" content="Luis Torres is an art director, designer, artist and front-end developer in Irvine and Los Angeles.">
+    <meta name="description" content="Luis Torres is a designer and front-end developer in Irvine and Los Angeles.">
     <meta name="keywords" content="Luis Torres LinkedIn Amazon Frontend Engineer Los Angeles Orange County Irvine San Francisco web developer design systems">
     <meta name="author" content="Luis Torres">
 
@@ -21,7 +21,7 @@
     <!-- Facebook Metas -->
     <meta property="og:url" content="https://theluistorres.com/">
     <meta property="og:site_name" content="Luis Torres | Work Hard Play Hard!">
-    <meta property="og:description" content="Luis Torres is an art director, designer, artist and front-end developer in Irvine and Los Angeles.">
+    <meta property="og:description" content="Luis Torres is a designer and front-end developer in Irvine and Los Angeles.">
     <meta property="og:image" content="https://theluistorres.com/dist/assets/img/social/facebook-object.jpg">
     <meta property="og:title" content="Luis Torres | Work Hard Play Hard!">
 
@@ -30,7 +30,7 @@
     <meta name="twitter:site" content="@luistorres1423">
     <meta name="twitter:creator" content="@luistorres1423">
     <meta name="twitter:title" content="Luis Torres | Work Hard Play Hard!">
-    <meta name="twitter:description" content="Luis Torres is an art director, designer, artist and front-end developer in Irvine and Los Angeles.">
+    <meta name="twitter:description" content="Luis Torres is a designer and front-end developer in Irvine and Los Angeles.">
     <meta name="twitter:image" content="https://theluistorres.com/dist/assets/img/social/twitter-card.jpg">
 
     <link rel="manifest" href="/manifest.json">
@@ -120,10 +120,10 @@
           <h3 class="widthFitContent">Work</h3>
           <ul class="listStyleNone paddingNone">
             <li>LinkedIn</li>
+            <li>Grammarly</li>
+            <li>Superhuman</li>
             <li>Amazon</li>
             <li>Discover</li>
-            <li>Verizon</li>
-            <li>Invensys</li>
           </ul>
         </div>
         <div class="gridItem column gapThree">

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
           <h3 class="widthFitContent">Work</h3>
           <ul class="listStyleNone paddingNone">
             <li>Superhuman</li>
+            <li>Grammarly</li>
             <li>LinkedIn</li>
             <li>Amazon</li>
             <li>Discover</li>
@@ -154,19 +155,19 @@
       </div>
 
       <div class="grid container gapThree">
-        <div class="gridItem box background" style="--backgroundColor: #34ace0; aspect-ratio: 1; border-radius: 30% 70% 70% 30% / 30% 30% 70% 70%;">
+        <div class="gridItem box background blob" style="--backgroundColor: #34ace0; aspect-ratio: 1; border-radius: 30% 70% 70% 30% / 30% 30% 70% 70%;">
           <h4 class="center textAlignCenter typographyHeading overlayText">LinkedIn's rebranding</h4>
         </div>
 
-        <div class="gridItem box background" style="--backgroundColor: #2c2c54; aspect-ratio: 1; border-radius: 61% 39% 41% 59% / 51% 30% 70% 49%;">
+        <div class="gridItem box background blob" style="--backgroundColor: #2c2c54; aspect-ratio: 1; border-radius: 61% 39% 41% 59% / 51% 30% 70% 49%;">
           <h4 class="center textAlignCenter typographyHeading overlayText">LinkedIn's Dark Mode</h4>
         </div>
 
-        <div class="gridItem box background" style="--backgroundColor: #33d9b2; aspect-ratio: 1; border-radius: 31% 69% 19% 81% / 50% 46% 54% 50%;">
+        <div class="gridItem box background blob" style="--backgroundColor: #33d9b2; aspect-ratio: 1; border-radius: 31% 69% 19% 81% / 50% 46% 54% 50%;">
           <h4 class="center textAlignCenter typographyHeading overlayText">Figma Plugins @ LinkedIn</h4>
         </div>
 
-        <div class="gridItem box background" style="--backgroundColor: #aaa69d; aspect-ratio: 1; border-radius: 53% 47% 57% 43% / 69% 46% 54% 31%;">
+        <div class="gridItem box background blob" style="--backgroundColor: #aaa69d; aspect-ratio: 1; border-radius: 53% 47% 57% 43% / 69% 46% 54% 31%;">
           <h4 class="center textAlignCenter typographyHeading overlayText">A11y @ LinkedIn</h4>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -96,10 +96,10 @@
           I am a Frontend Engineer passionate about building <strong>scalable</strong>, <strong>accessible</strong>, and <strong>intuitive</strong> UI experiences. Experienced in frontend infrastructure and design systems. Skilled at bridging design and engineering to drive alignment and improve workflows to ship faster.
         </p>
         <p>
-          Currently working at <a href="https://www.linkedin.com/" target="_blank" style="--colorAction: #0a66c2;">LinkedIn</a> on the Infrastructure UX team.
+          Currently working at <a href="https://superhuman.com/" target="_blank" style="--colorAction: #a35cff;">Superhuman</a>.
         </p>
         <p>
-          I previously worked at <a href="https://www.amazon.com/" target="_blank" style="--colorAction: #ff9900;">Amazon</a> on the Alexa team.
+          I previously worked at <a href="https://www.linkedin.com/" target="_blank" style="--colorAction: #0a66c2;">LinkedIn</a> on the Infrastructure UX team and at <a href="https://www.amazon.com/" target="_blank" style="--colorAction: #ff9900;">Amazon</a> on the Alexa team.
         </p>
         <p>
           I am committed to mentoring, knowledge-sharing, and pushing the boundaries of modern web development. Hence, I am currently running a blog called <a href="https://medium.com/@projectluis" target="_blank" style="--colorAction: #3c346d;">UI Gems</a> where we explore all the UI Gems around us.
@@ -119,9 +119,8 @@
         <div class="gridItem column gapThree">
           <h3 class="widthFitContent">Work</h3>
           <ul class="listStyleNone paddingNone">
-            <li>LinkedIn</li>
-            <li>Grammarly</li>
             <li>Superhuman</li>
+            <li>LinkedIn</li>
             <li>Amazon</li>
             <li>Discover</li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <meta name="description" content="Luis Torres is an art director, designer, artist and front-end developer in Irvine and Los Angeles.">
-    <meta name="keywords" contet="Luis Torres Amazon Btiful Los Angeles Orange County Irvine Tech art director designer artist paiting web developer">
+    <meta name="keywords" content="Luis Torres LinkedIn Amazon Frontend Engineer Los Angeles Orange County Irvine San Francisco web developer design systems">
     <meta name="author" content="Luis Torres">
 
     <!-- Theme Color -->
@@ -17,10 +17,6 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="format-detection" content="telephone=no">
-    <link rel="apple-touch-icon-precomposed" href="dist/assets/img/icons/Icon-54.png">
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="dist/assets/img/icons/Icon-72.png">
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="dist/assets/img/icons/Icon-114.png">
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="dist/assets/img/icons/Icon-144.png">
 
     <!-- Facebook Metas -->
     <meta property="og:url" content="https://theluistorres.com/">
@@ -35,7 +31,7 @@
     <meta name="twitter:creator" content="@luistorres1423">
     <meta name="twitter:title" content="Luis Torres | Work Hard Play Hard!">
     <meta name="twitter:description" content="Luis Torres is an art director, designer, artist and front-end developer in Irvine and Los Angeles.">
-    <meta name="twitter:image" content="http://theluistorres.com/dist/assets/img/social/twitter-card.jpg">
+    <meta name="twitter:image" content="https://theluistorres.com/dist/assets/img/social/twitter-card.jpg">
 
     <link rel="manifest" href="/manifest.json">
 
@@ -44,30 +40,13 @@
     <link href="https://fonts.googleapis.com/css?family=Raleway:200,400,800" rel="stylesheet">
 
     <!-- CSS -->
-    <!-- <link rel="stylesheet" href="dist/assets/css/luis.min.css"> -->
     <link rel="stylesheet" href="src/css/luis.css">
-
-    <!-- Favicons -->
-    <link rel="shortcut icon" type="image/png" href="dist/assets/img/icons/favicon.png">
-
-    <script type="text/javascript">htmlStartTime = Date.now();</script>
-
-    <!-- Google Analytics -->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-67556114-1', 'auto');
-      ga('send', 'pageview');
-    </script>
   </head>
   <body>
     <section class="jumbotron">
       <div class="box fillAvailableHeight fillAvailableWidth name">
-        <div class="colorText center blendMutiply" style="--colorText: teal">Torres</div>
-        <div class="colorText center blendMutiply" style="--colorText: #333">Luis</div>
+        <div class="colorText center blendMultiply" style="--colorText: teal">Torres</div>
+        <div class="colorText center blendMultiply" style="--colorText: #333">Luis</div>
       </div>
     </section>
 
@@ -117,7 +96,7 @@
           I am a Frontend Engineer passionate about building <strong>scalable</strong>, <strong>accessible</strong>, and <strong>intuitive</strong> UI experiences. Experienced in frontend infrastructure and design systems. Skilled at bridging design and engineering to drive alignment and improve workflows to ship faster.
         </p>
         <p>
-          Currently working at <a href="https://www.amazon.com/appstore" target="_blank" style="--colorAction: #0a66c2;">Linkedin</a> on the Infrastructure UX team.
+          Currently working at <a href="https://www.linkedin.com/" target="_blank" style="--colorAction: #0a66c2;">LinkedIn</a> on the Infrastructure UX team.
         </p>
         <p>
           I previously worked at <a href="https://www.amazon.com/" target="_blank" style="--colorAction: #ff9900;">Amazon</a> on the Alexa team.
@@ -175,7 +154,7 @@
         <h2>Some things I've worked on</h2>
       </div>
 
-      <div class="grid gapThree" style="padding-inline: 0.8rem; padding-block-end: 2%;">
+      <div class="grid container gapThree">
         <div class="gridItem box background" style="--backgroundColor: #34ace0; aspect-ratio: 1; border-radius: 30% 70% 70% 30% / 30% 30% 70% 70%;">
           <h4 class="center textAlignCenter typographyHeading overlayText">LinkedIn's rebranding</h4>
         </div>
@@ -194,29 +173,5 @@
       </div>
     </section>
 
-    <script type="text/javascript">
-      (function() {
-        // Load time
-        loadTime = Date.now();
-      }())
-
-      window.addEventListener('load', function() {
-        // Window Load time
-        windowLoadTime = Date.now();
-      });
-
-      document.onreadystatechange = function() {
-        if (document.readyState === 'interactive') {
-          // Interactive DOM time
-          interactiveDOMTime = Date.now();
-        } else if (document.readyState === 'complete') {
-          // Complete DOM time
-          completeDOMTime = Date.now();
-        }
-      }
-    </script>
-    <script type="text/javascript">applicationStartTime=Date.now();</script>
-    <!-- <script src="dist/assets/js/main.min.js"></script> -->
-    <script type="text/javascript">jsStartTime=Date.now();</script>
   </body>
 </html>

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -58,12 +58,12 @@
     border-bottom: 2px #fff solid;
   }
 
-  .work .gridItem.box {
+  .blob {
     transition: border-radius 0.6s ease-in-out;
-  }
 
-  .work .gridItem.box:hover {
-    animation: blob-morph 8s ease-in-out infinite;
+    &:hover {
+      animation: blob-morph 8s ease-in-out infinite;
+    }
   }
 
   @keyframes blob-morph {

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -57,4 +57,27 @@
     padding-bottom: .4rem;
     border-bottom: 2px #fff solid;
   }
+
+  .work .gridItem.box {
+    transition: border-radius 0.6s ease-in-out;
+  }
+
+  .work .gridItem.box:hover {
+    animation: blob-morph 8s ease-in-out infinite;
+  }
+
+  @keyframes blob-morph {
+    0%, 100% {
+      border-radius: 60% 40% 30% 70% / 60% 30% 70% 40%;
+    }
+    25% {
+      border-radius: 30% 70% 70% 30% / 50% 40% 60% 50%;
+    }
+    50% {
+      border-radius: 50% 50% 30% 70% / 40% 60% 50% 50%;
+    }
+    75% {
+      border-radius: 40% 60% 60% 40% / 70% 30% 50% 60%;
+    }
+  }
 }

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -1,33 +1,12 @@
 @layer components {
   .jumbotron {
-    height: 20rem;
+    height: clamp(20rem, 40vw, 60rem);
     position: relative;
     overflow: hidden;
-    /* background-image: radial-gradient(circle at center center, transparent,rgb(255,255,255)),linear-gradient(309deg, rgba(90, 90, 90,0.05) 0%, rgba(90, 90, 90,0.05) 50%,rgba(206, 206, 206,0.05) 50%, rgba(206, 206, 206,0.05) 100%),linear-gradient(39deg, rgba(13, 13, 13,0.05) 0%, rgba(13, 13, 13,0.05) 50%,rgba(189, 189, 189,0.05) 50%, rgba(189, 189, 189,0.05) 100%),linear-gradient(144deg, rgba(249, 249, 249,0.05) 0%, rgba(249, 249, 249,0.05) 50%,rgba(111, 111, 111,0.05) 50%, rgba(111, 111, 111,0.05) 100%),linear-gradient(166deg, rgba(231, 231, 231,0.05) 0%, rgba(231, 231, 231,0.05) 50%,rgba(220, 220, 220,0.05) 50%, rgba(220, 220, 220,0.05) 100%),linear-gradient(212deg, rgba(80, 80, 80,0.05) 0%, rgba(80, 80, 80,0.05) 50%,rgba(243, 243, 243,0.05) 50%, rgba(243, 243, 243,0.05) 100%),radial-gradient(circle at center center, hsl(107,19%,100%),hsl(107,19%,100%)); */
-    /* background-image: linear-gradient(62deg, #8EC5FC 0%, #E0C3FC 100%); */
     background:
       linear-gradient(217deg, rgba(255, 0, 0, 0.8), rgba(255, 0, 0, 0) 70.71%),
       linear-gradient(127deg, rgba(0, 255, 0, 0.8), rgba(0, 255, 0, 0) 70.71%),
       linear-gradient(336deg, rgba(0, 0, 255, 0.8), rgba(0, 0, 255, 0) 70.71%);
-    /* background:
-      linear-gradient(217deg, rgba(197, 197, 197, 0.8), rgba(255, 0, 0, 0) 70.71%),
-      linear-gradient(127deg, rgba(226, 226, 226, 0.8), rgba(0, 255, 0, 0) 70.71%),
-      linear-gradient(336deg, rgba(128, 128, 128, 0.8), rgba(0, 0, 255, 0) 70.71%); */
-  
-    transition: height 0.3s linear;
-  
-    /* Use clamp */
-    @media (min-width: 46rem) and (max-width: 64rem) {
-      height: 40rem;
-    }
-  
-    @media (min-width: 46rem) and (max-width: 96rem) {
-      height: 50rem;
-    }
-  
-    @media (min-width: 96rem) {
-      height: 60rem;
-    }
   }
   
   .name {

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -7,29 +7,11 @@
   /* Remove default margin */
   * {
     margin: 0;
-
-    /* Experimental line-height */
-    /* line-height: calc(2px + 2ex + 2px); */
   }
 
   html {
-    /* 1rem = 10px */
-    font-size: 62.5%;
-
-    /* Enable keyword animations */
     @media (prefers-reduced-motion: no-preference) {
-      /* Enable smooth scrolling */
       scroll-behavior: smooth;
-      /* Enable keyword animations */
-      interpolate-size: allow-keywords;
-    }
-  }
-
-  @media (prefers-reduced-motion: no-preference) {
-    html {
-      /* Enable smooth scrolling */
-      scroll-behavior: smooth;
-      /* Enable keyword animations */
       interpolate-size: allow-keywords;
     }
   }

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -28,51 +28,39 @@
   
   body {
     font-family: var(--baseFont);
-    /* color: #767676; */
   }
   
   h1 {
-    font-size: 2.4rem;
+    font-size: clamp(2.4rem, 2vw + 1.6rem, 3.5rem);
     line-height: 1.25;
   }
-  
+
+  h2 {
+    font-size: clamp(1.6rem, 1.5vw + 1rem, 2rem);
+    line-height: 1.25;
+  }
+
   p {
-    font-size: 1.6rem;
+    font-size: clamp(1.6rem, 1vw + 1.2rem, 2rem);
     font-family: var(--paragraphFont);
     margin-top: 2.4rem;
   }
-  
+
   a {
     color: var(--colorAction);
     font-weight: 800;
     text-decoration: none;
-  
+
     &:hover {
       text-decoration: underline;
     }
   }
-  
+
   h3, ul {
     font-size: 1.6rem;
   }
 
   ul {
     font-family: var(--paragraphFont);
-  }
-
-  /* Use clamp for all of these */
-  @media (width > 640px) {
-    h1 {
-      font-size: 3.5rem;
-    }
-
-    h2 {
-      font-size: 2rem;
-      line-height: 40px;
-    }
-
-    p {
-      font-size: 2rem;
-    }
   }
 }

--- a/src/css/utilities.css
+++ b/src/css/utilities.css
@@ -1,6 +1,7 @@
 @layer utilities {
   .row {
     display: flex;
+    flex-wrap: wrap;
   }
   
   .column {
@@ -19,12 +20,6 @@
   .grid {
     --gridColumns: 4;
     display: grid;
-    /* grid-template-columns: repeat(var(--gridColumns), minmax(200px, 1fr));
-    
-    @media (width < 640px) {
-      grid-template-columns: 1fr;
-    } */
-
     grid-template-columns: 1fr;
 
     @media (width > 640px) {
@@ -90,7 +85,7 @@
     justify-self: end;
   }
   
-  .blendMutiply {
+  .blendMultiply {
     mix-blend-mode: multiply;
   }
   


### PR DESCRIPTION
- Fix LinkedIn link pointing to Amazon App Store instead of linkedin.com
- Fix meta keywords typo (contet -> content) and update keywords
- Fix CNAME to match actual domain (theluistorres.com)
- Fix twitter:image using http instead of https
- Fix blendMutiply typo -> blendMultiply in CSS and HTML
- Remove broken apple-touch-icon and favicon refs (icons dir doesn't exist)
- Remove deprecated Universal Analytics script (stopped processing Jul 2023)
- Remove unused timing/perf scripts and commented-out CSS/JS links
- Remove all commented-out CSS code across components, utilities, reset, theme
- Replace jumbotron media queries with single clamp() for responsive height
- Replace typography media queries with clamp() for fluid type scaling
- Fix h2 line-height from px to unitless value
- Fix duplicate html rules between reset.css and theme.css
- Fix overlapping media queries in jumbotron (46-64rem overridden by 46-96rem)
- Add flex-wrap to .row for contact icons on narrow screens
- Replace inline padding style on work grid with container class

https://claude.ai/code/session_01RzVW8Se3cWTjeBXezL2Ne7