### PR TITLE
Fix CNAME to restore projectluis.com domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-theluistorres.com
+projectluis.com


### PR DESCRIPTION
The previous cleanup commit incorrectly changed the CNAME from projectluis.com to theluistorres.com, breaking the live site.

https://claude.ai/code/session_01RzVW8Se3cWTjeBXezL2Ne7