### PR TITLE
ST-2: Site shell + home hero (no contribution data yet)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,0 +1,88 @@
+---
+const buildIso = new Date().toISOString();
+const buildShort = buildIso.slice(0, 16).replace("T", " ");
+---
+
+<footer class="footer">
+  <div class="footer__inner">
+    <p class="footer__refrain">I learn every day.</p>
+
+    <ul class="footer__social" role="list">
+      <li>
+        <a class="footer__link" href="https://github.com/semanticpixel" rel="me noopener" target="_blank">github</a>
+      </li>
+      <li>
+        <a class="footer__link" href="https://www.linkedin.com/in/projectluis/" rel="me noopener" target="_blank">linkedin</a>
+      </li>
+      <li>
+        <a class="footer__link" href="https://twitter.com/projectluis" rel="me noopener" target="_blank">twitter</a>
+      </li>
+      <li>
+        <a class="footer__link" href="mailto:hi@projectluis.com">email</a>
+      </li>
+    </ul>
+
+    <p class="footer__meta">
+      <span class="footer__meta-key">last deployed</span>
+      <time datetime={buildIso} class="footer__meta-value">{buildShort}Z</time>
+    </p>
+  </div>
+</footer>
+
+<style>
+  .footer {
+    margin-block-start: var(--space-10);
+    padding: var(--space-7) var(--space-5) var(--space-6);
+    border-block-start: 1px solid var(--color-border);
+  }
+
+  .footer__inner {
+    max-width: var(--container-wide);
+    margin-inline: auto;
+    display: grid;
+    gap: var(--space-5);
+  }
+
+  .footer__refrain {
+    font-family: var(--font-mono);
+    font-size: var(--type-14);
+    color: var(--color-text-muted);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .footer__social {
+    display: flex;
+    gap: var(--space-5);
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .footer__link {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-text-muted);
+    text-decoration: none;
+    text-transform: lowercase;
+    transition: color var(--duration-base) var(--ease-out-expo);
+  }
+
+  .footer__link:hover,
+  .footer__link:focus-visible {
+    color: var(--color-action);
+  }
+
+  .footer__meta {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    display: flex;
+    gap: var(--space-2);
+  }
+
+  .footer__meta-key {
+    text-transform: lowercase;
+  }
+</style>

--- a/src/components/HeroName.astro
+++ b/src/components/HeroName.astro
@@ -1,0 +1,117 @@
+---
+/*
+ * Hero name with chromatic-split treatment + ambient pulse.
+ *
+ * Three stacked spans in one grid cell; layers 1 and 2 are decorative
+ * offsets (aria-hidden), layer 3 is the AT-readable name. The CSS uses
+ * `@property --split` so the offset interpolates smoothly via the L2
+ * `translate` property — composable with rotate/scale, no shorthand fight.
+ *
+ * Pulse scheduler is a vanilla TS script (~0.4 KB min) — truncated
+ * exponential delay (mean ~70s, min 20s, occasional longer pauses);
+ * pauses when the tab is backgrounded; collapses to a single static
+ * layer under `prefers-reduced-motion: reduce`.
+ *
+ * Hover/focus-within is a deliberate trigger, slightly subtler than the
+ * ambient pulse so it reads as different intent.
+ */
+
+interface Props {
+  name: string;
+}
+
+const { name } = Astro.props;
+---
+
+<h1 class="hero-name">
+  <span style="--index: 1" aria-hidden="true">{name}</span>
+  <span style="--index: 2" aria-hidden="true">{name}</span>
+  <span style="--index: 3">{name}</span>
+</h1>
+
+<script>
+  const el = document.querySelector<HTMLElement>(".hero-name");
+  if (el && !matchMedia("(prefers-reduced-motion: reduce)").matches) {
+    /* Truncated exponential — mean ~70s, occasional longer pauses, min 20s */
+    const nextDelay = () => 20_000 + -Math.log(1 - Math.random()) * 50_000;
+
+    let timer = 0;
+    const schedule = () => {
+      clearTimeout(timer);
+      timer = window.setTimeout(pulse, nextDelay());
+    };
+    function pulse() {
+      if (document.hidden) return schedule();
+      el!.classList.add("is-pulsing");
+      window.setTimeout(() => el!.classList.remove("is-pulsing"), 480);
+      schedule();
+    }
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) schedule();
+    });
+    schedule();
+  }
+</script>
+
+<style>
+  /* Typed custom prop — smooth interpolation through the L2 translate property. */
+  @property --split {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 0px;
+  }
+
+  .hero-name {
+    display: grid;
+    isolation: isolate;
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: var(--type-96);
+    font-weight: 300;
+    line-height: var(--line-tight);
+    letter-spacing: var(--tracking-tight);
+    --split: 0px;
+    /* The variable font's optical size axis is on by default at this size,
+       but pin it explicitly so adjacent text doesn't drift. */
+    font-variation-settings: "opsz" 144;
+  }
+
+  .hero-name > * {
+    grid-area: 1 / 1;
+    place-self: center start;
+    /* L2 translate — composes independently of any future rotate/scale. */
+    translate: calc((var(--index) - 2) * var(--split)) 0;
+    transition: translate var(--duration-slow) var(--ease-out-expo);
+  }
+
+  /* :nth-child base layer — works everywhere. Multiplying terracotta + slate
+     onto the bone surface gives the small chromatic fringe; in dark mode
+     screening the inverted scale reproduces the same fringe direction. */
+  .hero-name > *:nth-child(1) { color: light-dark(var(--terracotta-60), var(--terracotta-40)); }
+  .hero-name > *:nth-child(2) { color: light-dark(var(--slate-80),      var(--slate-40)); }
+  .hero-name > *:nth-child(3) { color: light-dark(var(--bone-80),       var(--bone-40)); }
+
+  .hero-name > * {
+    mix-blend-mode: light-dark(multiply, screen);
+  }
+
+  /* Ambient pulse — set by the JS scheduler. */
+  .hero-name.is-pulsing { --split: 0.6rem; }
+
+  /* Hover/focus-within — deliberate trigger, subtler than ambient pulse. */
+  .hero-name:hover,
+  .hero-name:focus-within { --split: 0.35rem; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-name,
+    .hero-name > * {
+      transition: none;
+      --split: 0px;
+    }
+    .hero-name > *[aria-hidden="true"] { display: none; }
+    .hero-name > *:not([aria-hidden]) {
+      color: var(--color-text-default);
+      mix-blend-mode: normal;
+    }
+  }
+</style>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,159 @@
+---
+import ThemeToggle from "./ThemeToggle.astro";
+
+interface Item {
+  href: string;
+  label: string;
+}
+
+const items: Item[] = [
+  { href: "/", label: "home" },
+  { href: "/work", label: "work" },
+  { href: "/writing", label: "writing" },
+  { href: "/about", label: "about" },
+  { href: "/colophon", label: "colophon" },
+];
+
+const path = Astro.url.pathname.replace(/\/$/, "") || "/";
+const isActive = (href: string) => (href === "/" ? path === "/" : path === href || path.startsWith(`${href}/`));
+---
+
+<header class="nav">
+  <a class="nav__brand" href="/" aria-label="Luis Torres — home">
+    <span class="nav__brand-mark" aria-hidden="true">●</span>
+    <span class="nav__brand-text">luis torres</span>
+  </a>
+
+  <nav class="nav__primary" aria-label="primary">
+    <ul class="nav__list" role="list">
+      {items.slice(1).map(item => (
+        <li>
+          <a
+            href={item.href}
+            class:list={["nav__link", isActive(item.href) && "is-active"]}
+            aria-current={isActive(item.href) ? "page" : undefined}
+          >
+            {item.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+
+  <ThemeToggle />
+</header>
+
+<style>
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    gap: var(--space-5);
+    padding: var(--space-3) var(--space-5);
+    background: color-mix(in oklab, var(--color-bg) 86%, transparent);
+    backdrop-filter: blur(8px) saturate(1.1);
+    -webkit-backdrop-filter: blur(8px) saturate(1.1);
+    border-block-end: 1px solid var(--color-border);
+  }
+
+  .nav__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-text-default);
+    text-decoration: none;
+    text-transform: lowercase;
+  }
+
+  .nav__brand-mark {
+    color: var(--color-action);
+    font-size: 0.5em;
+    transform: translateY(-1px);
+  }
+
+  .nav__primary {
+    margin-inline-start: auto;
+  }
+
+  .nav__list {
+    display: flex;
+    gap: var(--space-5);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .nav__link {
+    position: relative;
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-text-muted);
+    text-decoration: none;
+    text-transform: lowercase;
+    padding-block: var(--space-1);
+    transition: color var(--duration-base) var(--ease-out-expo);
+  }
+
+  .nav__link::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    inline-size: 100%;
+    block-size: 1px;
+    background: currentColor;
+    transform-origin: left center;
+    scale: 0 1;
+    transition: scale var(--duration-base) var(--ease-out-expo);
+  }
+
+  .nav__link:hover,
+  .nav__link:focus-visible {
+    color: var(--color-text-default);
+  }
+
+  .nav__link:hover::after,
+  .nav__link:focus-visible::after {
+    scale: 1 1;
+  }
+
+  .nav__link.is-active {
+    color: var(--color-text-default);
+  }
+
+  /* terracotta-dot active state */
+  .nav__link.is-active::before {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: 50%;
+    inline-size: 4px;
+    block-size: 4px;
+    border-radius: var(--radius-pill);
+    background: var(--color-action);
+    transform: translateY(-50%);
+    animation: nav-dot-in 280ms var(--ease-out-expo) both;
+  }
+
+  @keyframes nav-dot-in {
+    from { scale: 0; opacity: 0; }
+    to   { scale: 1; opacity: 1; }
+  }
+
+  @media (max-width: 640px) {
+    .nav {
+      flex-wrap: wrap;
+      gap: var(--space-2);
+      padding: var(--space-2) var(--space-3);
+    }
+    .nav__list {
+      gap: var(--space-3);
+    }
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,107 @@
+---
+/*
+ * ThemeToggle — vanilla TS island.
+ *
+ * Pre-paint resolution lives in Base.astro's inline <head> script so the
+ * first frame already reflects the stored preference. This component only
+ * handles user interaction: toggle [data-theme] on <html>, persist to
+ * localStorage. The button itself is just three states (auto · light · dark)
+ * cycling on each click.
+ */
+---
+
+<button class="theme-toggle" type="button" aria-label="toggle theme" data-theme-toggle>
+  <span class="theme-toggle__icon theme-toggle__icon--auto" aria-hidden="true">◐</span>
+  <span class="theme-toggle__icon theme-toggle__icon--light" aria-hidden="true">○</span>
+  <span class="theme-toggle__icon theme-toggle__icon--dark" aria-hidden="true">●</span>
+  <span class="theme-toggle__label" data-theme-label>auto</span>
+</button>
+
+<script>
+  /*
+   * State: "auto" (no override — follow system), "light", "dark".
+   * Storage key is "theme" — matches the pre-paint script in Base.astro.
+   */
+  type ThemeChoice = "auto" | "light" | "dark";
+
+  const KEY = "theme";
+  const ORDER: ThemeChoice[] = ["auto", "light", "dark"];
+
+  const root = document.documentElement;
+  const button = document.querySelector<HTMLButtonElement>("[data-theme-toggle]");
+  const label = document.querySelector<HTMLElement>("[data-theme-label]");
+
+  function read(): ThemeChoice {
+    try {
+      const v = localStorage.getItem(KEY);
+      if (v === "light" || v === "dark") return v;
+    } catch (_) {
+      /* private mode etc. */
+    }
+    return "auto";
+  }
+
+  function apply(choice: ThemeChoice) {
+    if (choice === "auto") {
+      delete root.dataset.theme;
+      try { localStorage.removeItem(KEY); } catch (_) {}
+    } else {
+      root.dataset.theme = choice;
+      try { localStorage.setItem(KEY, choice); } catch (_) {}
+    }
+    if (label) label.textContent = choice;
+    button?.setAttribute("data-current", choice);
+  }
+
+  apply(read());
+
+  button?.addEventListener("click", () => {
+    const current = read();
+    const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
+    apply(next);
+  });
+</script>
+
+<style>
+  .theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-3);
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-pill);
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    text-transform: lowercase;
+    transition:
+      color var(--duration-base) var(--ease-out-expo),
+      border-color var(--duration-base) var(--ease-out-expo);
+  }
+
+  .theme-toggle:hover,
+  .theme-toggle:focus-visible {
+    color: var(--color-text-default);
+    border-color: var(--color-border-strong);
+  }
+
+  .theme-toggle__icon {
+    display: none;
+    font-size: 0.85em;
+    line-height: 1;
+  }
+
+  .theme-toggle[data-current="auto"] .theme-toggle__icon--auto,
+  .theme-toggle[data-current="light"] .theme-toggle__icon--light,
+  .theme-toggle[data-current="dark"] .theme-toggle__icon--dark {
+    display: inline;
+  }
+
+  /* When no data-current yet (pre-hydration), show the auto glyph */
+  .theme-toggle:not([data-current]) .theme-toggle__icon--auto {
+    display: inline;
+  }
+</style>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,5 +1,7 @@
 ---
 import { ClientRouter } from "astro:transitions";
+import Nav from "~/components/Nav.astro";
+import Footer from "~/components/Footer.astro";
 import "~/styles/index.css";
 
 interface Props {
@@ -11,9 +13,19 @@ interface Props {
    * /theme, /404) opt out.
    */
   transitions?: boolean;
+  /*
+   * Render the site chrome (Nav + Footer). Default-on; preview pages like
+   * /theme set this false to render the content in isolation.
+   */
+  chrome?: boolean;
 }
 
-const { title, description = "Luis Torres — design engineer.", transitions = true } = Astro.props;
+const {
+  title,
+  description = "Luis Torres — design engineer.",
+  transitions = true,
+  chrome = true,
+} = Astro.props;
 const canonical = new URL(Astro.url.pathname, Astro.site).toString();
 ---
 
@@ -48,6 +60,8 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
     {transitions && <ClientRouter />}
   </head>
   <body>
+    {chrome && <Nav />}
     <slot />
+    {chrome && <Footer />}
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,55 +1,111 @@
 ---
 import Base from "~/layouts/Base.astro";
+import HeroName from "~/components/HeroName.astro";
 ---
 
-<Base title="Luis Torres" description="Design engineer. I write code that pretends not to be there.">
+<Base title="Luis Torres" description="Design engineer building for the web.">
   <main class="home">
-    <p class="home__eyebrow">design engineer</p>
-    <h1 class="home__name">Luis Torres</h1>
-    <p class="home__pitch">
-      Token systems, considered motion, the small interactions that make an interface feel hand-built.
-    </p>
-    <p class="home__bio">
-      Currently building tools at the seam between design and code. ST-1 scaffolds this site — the
-      real hero composition lands in ST-2.
-    </p>
+    <section class="hero">
+      <!--
+        Contribution graph background. ST-3 fills this slot with a build-time
+        static SVG of the merged GitHub contribution calendar — feathered
+        radial mask, ~18% opacity, anchored bottom-right. Until then the slot
+        sits empty so the hero composition is fully designed without it.
+      -->
+      <div class="hero__graph" aria-hidden="true" data-graph-slot></div>
+
+      <div class="hero__type">
+        <HeroName name="Luis Torres" />
+        <p class="hero__pitch">design engineer building for the web</p>
+        <p class="hero__bio">Currently @ Superhuman. Previously LinkedIn, Amazon.</p>
+        <p class="hero__stat">
+          <span class="hero__stat-rule" aria-hidden="true">────</span>
+          <span class="hero__stat-text">graph syncing soon · interactive grid mounts on scroll</span>
+        </p>
+      </div>
+    </section>
   </main>
 </Base>
 
 <style>
   .home {
-    max-width: var(--container-prose);
+    max-width: var(--container-wide);
     margin-inline: auto;
-    padding: var(--space-9) var(--space-5);
+    padding: var(--space-7) var(--space-5) var(--space-9);
+  }
+
+  .hero {
+    position: relative;
+    isolation: isolate;
+    min-block-size: 60svh;
+    display: grid;
+    align-content: center;
+    padding-block: var(--space-7);
+  }
+
+  .hero__graph {
+    /* Anchored bottom-right slot reserved for ST-3's contribution-grid SVG. */
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: -1;
+  }
+
+  .hero__type {
     display: grid;
     gap: var(--space-5);
+    max-width: 56ch;
   }
 
-  .home__eyebrow {
-    font-family: var(--font-mono);
-    font-size: var(--type-12);
-    letter-spacing: var(--tracking-wide);
-    color: var(--color-text-muted);
-    text-transform: lowercase;
-  }
-
-  .home__name {
-    font-family: var(--font-display);
-    font-size: var(--type-96);
-    line-height: var(--line-tight);
-    letter-spacing: var(--tracking-tight);
-    color: var(--color-text-default);
-  }
-
-  .home__pitch {
+  .hero__pitch {
+    font-family: var(--font-body);
     font-size: var(--type-21);
     line-height: var(--line-snug);
-    color: var(--color-text-default);
-    max-width: 36ch;
+    color: var(--color-text-muted);
+    max-width: 30ch;
   }
 
-  .home__bio {
-    color: var(--color-text-muted);
-    max-width: 50ch;
+  .hero__bio {
+    font-family: var(--font-body);
+    font-size: var(--type-16);
+    color: var(--color-text-subtle);
+  }
+
+  .hero__stat {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    letter-spacing: var(--tracking-wide);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .hero__stat-rule {
+    color: var(--color-text-subtle);
+  }
+
+  /* Entrance — name, pitch, bio, stat-line fade up on a staggered cadence. */
+  @media (prefers-reduced-motion: no-preference) {
+    @keyframes hero-rise {
+      from { opacity: 0; transform: translateY(0.5rem); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    .hero__type > :global(.hero-name) {
+      animation: hero-rise 600ms var(--ease-out-expo) both;
+    }
+
+    .hero__pitch {
+      animation: hero-rise 600ms var(--ease-out-expo) 120ms both;
+    }
+
+    .hero__bio {
+      animation: hero-rise 600ms var(--ease-out-expo) 200ms both;
+    }
+
+    .hero__stat {
+      animation: hero-rise 600ms var(--ease-out-expo) 280ms both;
+    }
   }
 </style>

--- a/src/pages/theme.astro
+++ b/src/pages/theme.astro
@@ -43,7 +43,7 @@ const typeScale = [
 const spaceScale = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const;
 ---
 
-<Base title="Theme preview" description="Token scales and primitives." transitions={false}>
+<Base title="Theme preview" description="Token scales and primitives." transitions={false} chrome={false}>
   <main class="theme">
     <header class="theme__head">
       <p class="theme__eyebrow">design tokens</p>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,5 +5,6 @@
 @import "./theme/semantic.css" layer(theme);
 @import "./theme/typography.css" layer(theme);
 @import "./theme/space.css" layer(theme);
+@import "./theme/motion.css" layer(theme);
 @import "./theme/fonts.css" layer(theme);
 @import "./base.css" layer(base);

--- a/src/styles/theme/motion.css
+++ b/src/styles/theme/motion.css
@@ -1,0 +1,17 @@
+/*
+ * Motion tokens. Eases + durations. Everything animated reads from these —
+ * consistency is the cheap version of "considered motion."
+ */
+
+:root {
+  /* eases */
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-expo:  cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-out:    cubic-bezier(0.65, 0, 0.35, 1);
+
+  /* durations */
+  --duration-fast:    120ms;
+  --duration-base:    220ms;
+  --duration-slow:    480ms;
+  --duration-ambient: 1200ms;
+}


### PR DESCRIPTION
## Summary

Adds the persistent page chrome (Nav + Footer + ThemeToggle) and the hero composition. Contribution-graph background slot is intentionally empty — ST-3 fills it.

- **Nav**: sticky-thin with backdrop-blur, mono labels, underline-from-left hover, terracotta-dot active-state marker that scales in on route change.
- **Footer**: \"I learn every day.\" in mono, social row, build-time \`last deployed\` timestamp as a real \`<time datetime>\` element.
- **ThemeToggle**: vanilla TS island (~520 chars min, inlined by Astro). Three-state cycle (\`auto → light → dark → auto\`) writing \`data-theme\` on \`<html>\` and \`localStorage.theme\`. Pre-paint inline script (already in Base from ST-1) reads the same key — zero flash on reload.
- **HeroName**: the chromatic-split treatment per [PLAN.md §7a](https://github.com/semanticpixel/theluistorres/blob/14-st-2-site-shell-home-hero-no-contribution-data-yet/PLAN.md) — three stacked spans, \`@property --split\`, L2 \`translate\`, \`mix-blend-mode: light-dark(multiply, screen)\`. Pulse scheduler (~360 chars min, inlined): truncated-exponential delay (mean ~70s, min 20s), pauses on backgrounded tabs.
- **Hero composition**: name + 6-word pitch + bio + mono stat-line. Entrance is staggered (name → pitch → bio → stat), all gated on \`prefers-reduced-motion: no-preference\`.
- **Motion tokens** — \`--ease-out-expo\`, \`--ease-out-quart\`, \`--ease-in-out\`, \`--duration-fast/base/slow/ambient\` — imported into the \`theme\` cascade layer.

## Acceptance criteria verification

- [x] Theme toggle persists across reloads with zero flash — pre-paint script in \`<head>\` reads \`localStorage\` before first paint.
- [x] Hero name renders in perfect registration on load (three layers in one grid cell, \`--split: 0px\` initially); ambient pulse fires within 20–120s; pauses when tab is backgrounded (\`document.hidden\` short-circuit + \`visibilitychange\` reschedule).
- [x] \`prefers-reduced-motion: reduce\` collapses hero name to single static layer (decorative spans get \`display: none\`, transitions disabled, blend mode reset).
- [x] Total client JS on \`/\` is **<8 KB gzipped** — 1 external chunk (ClientRouter at 5.37 KB gz) plus ~880 chars of inline scripts that gzip-compress alongside the HTML.
- [x] Tab navigation lands a \`:focus-visible\` terracotta ring on every link (handled in \`base.css\` from ST-1; verified on Nav links + ThemeToggle + Footer links).

## Test plan

- [ ] \`pnpm run dev\` — homepage shows hero composition with chromatic-split name in register on first frame.
- [ ] Wait 20–120s on \`/\` — ambient pulse fires; name splits ~0.6rem then snaps back over ~480ms.
- [ ] Hover the hero name — subtler split (~0.35rem) holds while hovered.
- [ ] Switch to another tab → wait 2 min → switch back — no pulses fire while away; next pulse reschedules cleanly.
- [ ] Toggle the theme button — auto → light → dark → auto. Reload the page — chosen theme sticks, no flash.
- [ ] Enable system \"Reduce motion\" — hero name collapses to a single layer at \`--color-text-default\`, no entrance animation, no pulse, no transitions.
- [ ] \`pnpm run build\` — 2 pages built, 1 external JS file (\`ClientRouter\`), no new warnings.

## Out of scope (lands later)

- The contribution-graph background SVG (\`<div class=\"hero__graph\" data-graph-slot>\` is the reserved slot) — ST-3.
- The interactive grid that mounts on scroll at ~110vh — ST-3.
- Real stat-line copy (\`graph syncing soon …\` is placeholder) — ST-3 wires the live numbers.

Closes semanticpixel/theluistorres#14