### PR TITLE
ST-4: Content collections + work case studies (5 drafts)

### DIFF
--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -1,0 +1,105 @@
+---
+/*
+ * Prose — typographic wrapper for long-form MDX content.
+ *
+ * Scoped class so MDX selectors don't leak into other pages. Reads spacing
+ * and font tokens from the theme layer. Headings, lists, blockquotes, and
+ * code blocks all opt into the system measurements.
+ */
+---
+
+<div class="prose">
+  <slot />
+</div>
+
+<style>
+  .prose {
+    max-width: var(--container-prose);
+    margin-inline: auto;
+    color: var(--color-text-default);
+    font-family: var(--font-body);
+    font-size: var(--type-18);
+    line-height: 1.7;
+  }
+
+  .prose :global(h1),
+  .prose :global(h2),
+  .prose :global(h3),
+  .prose :global(h4) {
+    font-family: var(--font-display);
+    line-height: var(--line-tight);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-text-default);
+  }
+
+  .prose :global(h2) {
+    font-size: var(--type-28);
+    margin-block: var(--space-7) var(--space-3);
+  }
+
+  .prose :global(h3) {
+    font-size: var(--type-21);
+    margin-block: var(--space-5) var(--space-2);
+  }
+
+  .prose :global(p) {
+    margin-block: var(--space-4);
+  }
+
+  .prose :global(ul),
+  .prose :global(ol) {
+    margin-block: var(--space-4);
+    padding-inline-start: 1.5rem;
+  }
+
+  .prose :global(li) {
+    margin-block: var(--space-2);
+  }
+
+  .prose :global(blockquote) {
+    margin-block: var(--space-5);
+    padding-inline-start: var(--space-4);
+    border-inline-start: 2px solid var(--color-action);
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .prose :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.88em;
+    background: var(--color-surface);
+    padding: 0.1em 0.35em;
+    border-radius: var(--radius-sm);
+  }
+
+  .prose :global(pre) {
+    margin-block: var(--space-5);
+    padding: var(--space-4);
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    overflow-x: auto;
+    font-size: var(--type-14);
+  }
+
+  .prose :global(pre code) {
+    background: transparent;
+    padding: 0;
+  }
+
+  .prose :global(a) {
+    color: var(--color-action);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.2em;
+  }
+
+  .prose :global(a:hover),
+  .prose :global(a:focus-visible) {
+    color: var(--color-action-hover);
+  }
+
+  .prose :global(hr) {
+    margin-block: var(--space-7);
+    border: 0;
+    border-block-start: 1px solid var(--color-border);
+  }
+</style>

--- a/src/components/WorkCard.astro
+++ b/src/components/WorkCard.astro
@@ -1,0 +1,128 @@
+---
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  entry: CollectionEntry<"work">;
+  size?: "default" | "feature";
+}
+
+const { entry, size = "default" } = Astro.props;
+const { title, summary, tags, period, company } = entry.data;
+const slug = entry.id.replace(/\.(md|mdx)$/, "");
+---
+
+<a
+  class:list={["work-card", `work-card--${size}`]}
+  href={`/work/${slug}`}
+  aria-label={`${title} — read case study`}
+>
+  <div class="work-card__meta">
+    {period && <span class="work-card__period">{period}</span>}
+    {company && <span class="work-card__company">{company}</span>}
+  </div>
+
+  <h3 class="work-card__title">{title}</h3>
+
+  <p class="work-card__summary">{summary}</p>
+
+  {tags.length > 0 && (
+    <ul class="work-card__tags" role="list">
+      {tags.map(tag => (
+        <li class="work-card__tag">{tag}</li>
+      ))}
+    </ul>
+  )}
+</a>
+
+<style>
+  .work-card {
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-5);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: inherit;
+    text-decoration: none;
+    transition:
+      border-color var(--duration-base) var(--ease-out-expo),
+      transform var(--duration-base) var(--ease-out-expo);
+  }
+
+  .work-card:hover,
+  .work-card:focus-visible {
+    border-color: var(--color-border-strong);
+    transform: translateY(-2px);
+  }
+
+  .work-card--feature {
+    padding: var(--space-6);
+  }
+
+  .work-card__meta {
+    display: flex;
+    gap: var(--space-3);
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    text-transform: lowercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .work-card__period::after {
+    content: " ·";
+    color: var(--color-text-subtle);
+  }
+
+  .work-card__title {
+    font-family: var(--font-display);
+    font-size: var(--type-28);
+    line-height: var(--line-snug);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-text-default);
+    margin: 0;
+  }
+
+  .work-card--feature .work-card__title {
+    font-size: var(--type-40);
+  }
+
+  .work-card__summary {
+    color: var(--color-text-muted);
+    margin: 0;
+    max-width: 60ch;
+  }
+
+  .work-card__tags {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    margin-block-start: var(--space-2);
+  }
+
+  .work-card__tag {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    text-transform: lowercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .work-card__tag::before {
+    content: "#";
+    margin-inline-end: 0.1em;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .work-card {
+      transition: none;
+    }
+    .work-card:hover,
+    .work-card:focus-visible {
+      transform: none;
+    }
+  }
+</style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,0 +1,50 @@
+import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+/*
+ * Content collections.
+ *
+ * Both collections use the `glob` loader (Astro 5's replacement for the
+ * legacy `type: "content"` API). Each `.mdx` file under `src/content/<col>/`
+ * becomes one entry; Zod validates frontmatter at build time so a misshapen
+ * file fails `astro build` with a clear error rather than failing silently.
+ *
+ * The English / Spanish split for `work` is intentional — ST-6 adds
+ * `work-es` as a sibling collection that mirrors this schema. Keeping it
+ * as a separate collection (vs a `locale` field on one collection) means
+ * Spanish entries can opt out of being shipped with the English bundle.
+ */
+
+const work = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/work" }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string().min(1),
+      slug: z.string().regex(/^[a-z0-9-]+$/).optional(),
+      summary: z.string().min(1).max(280),
+      heroImage: image().optional(),
+      heroImageAlt: z.string().optional(),
+      tags: z.array(z.string().min(1)).default([]),
+      date: z.coerce.date(),
+      featured: z.boolean().default(false),
+      draft: z.boolean().default(false),
+      role: z.string().optional(),
+      company: z.string().optional(),
+      period: z.string().optional(),
+    }),
+});
+
+const writing = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/writing" }),
+  schema: z.object({
+    title: z.string().min(1),
+    slug: z.string().regex(/^[a-z0-9-]+$/).optional(),
+    summary: z.string().min(1).max(280),
+    externalUrl: z.string().url(),
+    date: z.coerce.date(),
+    readingTime: z.string().optional(),
+    tags: z.array(z.string().min(1)).default([]),
+  }),
+});
+
+export const collections = { work, writing };

--- a/src/content/work/grammarly-ai-detector.mdx
+++ b/src/content/work/grammarly-ai-detector.mdx
@@ -1,0 +1,44 @@
+---
+title: "Grammarly AI Detector — early experiments"
+summary: "Designing the UX for 'is this text AI-generated?' when the answer is statistical, not absolute."
+tags: ["ai", "ux", "prototyping"]
+date: 2023-11-05
+featured: false
+role: "Design Engineer"
+company: "Grammarly"
+period: "2023"
+---
+
+> 📝 **Claude draft — pending Luis's review.** Public-information framing.
+> Luis's specific contribution + the design decisions worth highlighting
+> need a first-person rewrite.
+
+The hard part of an AI detector isn't the model. It's the UI for *"probably."* Users want a yes/no; the model gives a confidence band; product needs both honesty and decisiveness. Resolving that gap is a design problem before it's an ML one.
+
+## Context
+
+In 2023 every writing surface was figuring out the same question: when AI-generated text appears in a draft (or arrives unsolicited from a colleague), what does the product *do* about it? Detection is a feature; *the way you present a probability* is the surface that earns trust. Get it wrong and you create new problems — false accusations, learned skepticism, gameable thresholds.
+
+## Move
+
+*Skeleton — needs Luis's first-person account:*
+
+- The presentation pattern you landed on (and the ones you ruled out)
+- How you handled the false-positive case in the UI — without burying the signal
+- The interaction model for "I disagree with this score"
+
+## Outcome
+
+*Skeleton — needs Luis's notes:*
+
+- Internal user research insights worth surfacing
+- The pattern that generalised to other Grammarly AI surfaces
+- The decision that didn't ship and why
+
+## What I'd do differently
+
+*Skeleton — needs Luis's retro:*
+
+- The visual encoding you'd change
+- The threshold conversation you'd reopen with the model team
+- The cross-functional pattern you'd push for earlier

--- a/src/content/work/linkedin-coach.mdx
+++ b/src/content/work/linkedin-coach.mdx
@@ -1,0 +1,44 @@
+---
+title: "LinkedIn Coach"
+summary: "The AI career coach: making generative AI feel like a colleague, not a chatbot."
+tags: ["ai", "design-systems", "product"]
+date: 2024-10-15
+featured: true
+role: "Design Engineer"
+company: "LinkedIn"
+period: "2023–2024"
+---
+
+> 📝 **Claude draft — pending Luis's review.** Public-knowledge framing only.
+> The "Move" + "Outcome" sections need first-person edits before they read as
+> Luis's voice rather than a generic case-study skeleton.
+
+LinkedIn shipped an AI career coach. The interesting question wasn't "can we get the model to give good advice" — model quality wasn't the bottleneck. The question was: **what does it feel like to ask an AI for career advice on a platform where your professional identity is the product?**
+
+## Context
+
+By 2023 most "AI inside the product" surfaces had collapsed into either a sidebar chatbot or a textbox-with-better-autocomplete. Both patterns punted on the harder question — what *role* does the AI play in the user's session? On LinkedIn, the user is presenting themselves; the AI's job had to be coaching, not co-piloting. A coach answers fewer questions but asks better ones.
+
+## Move
+
+*Skeleton — needs Luis's first-person account:*
+
+- What design decision separated this from "a chat sidebar"?
+- How did you tune the model's voice / question pattern so it read as a coach rather than a search engine?
+- What component-system work needed to land first to make the surface coherent at scale?
+
+## Outcome
+
+*Skeleton — needs Luis's metrics and headlines:*
+
+- Engagement / retention numbers from the launch
+- What the team learned about advice surfaces vs. answer surfaces
+- Downstream changes to other AI features in the product
+
+## What I'd do differently
+
+*Skeleton — needs Luis's honest retrospective:*
+
+- The thing I'd push back on harder, in hindsight
+- The pattern from this project that should have generalised faster across the rest of the product
+- What I learned about working with model teams on surfaces where the model's *style* matters as much as its accuracy

--- a/src/content/work/linkedin-dark-mode.mdx
+++ b/src/content/work/linkedin-dark-mode.mdx
@@ -1,0 +1,43 @@
+---
+title: "LinkedIn Dark Mode"
+summary: "A two-year token migration that turned dark mode from a setting into infrastructure."
+tags: ["design-systems", "color", "accessibility"]
+date: 2023-05-12
+featured: true
+role: "Design Engineer"
+company: "LinkedIn"
+period: "2021–2023"
+---
+
+> 📝 **Claude draft — pending Luis's review.** Framing reads cleanly; Move + Outcome
+> need Luis's first-person account of the actual rollout strategy.
+
+Dark mode looks like a toggle and is actually a token rewrite. On a product the size of LinkedIn, "ship dark mode" means inventory every hardcoded hex in the codebase, decide what it *meant* semantically, and then thread a semantic token through enough surfaces that the toggle has somewhere to act.
+
+## Context
+
+Most "dark mode ship-it" failures aren't visual — they're organisational. The team owning a particular surface has its own color values, its own brand opinions, its own deadlines. A central design-systems push needs a migration story that lets every surface land at its own pace without forking the palette.
+
+## Move
+
+*Skeleton — needs Luis's first-person account:*
+
+- The semantic-token model you landed on (and what you rejected)
+- The migration pattern that let teams ship dark-mode-correct surfaces incrementally
+- How you handled the long tail — illustrations, brand colours, third-party embeds — without blocking the launch
+
+## Outcome
+
+*Skeleton — needs Luis's launch story:*
+
+- Rollout sequence (geos, surfaces, employee dogfooding)
+- The internal-tools / docs work that made the token model legible to non-systems engineers
+- What the migration tally looked like when you called it complete
+
+## What I'd do differently
+
+*Skeleton — needs Luis's retro:*
+
+- The token I named wrong (and still regret)
+- A migration step you'd reorder
+- The thing about dual-mode design that production code makes obvious but design tools still hide

--- a/src/content/work/linkedin-design-system.mdx
+++ b/src/content/work/linkedin-design-system.mdx
@@ -1,0 +1,43 @@
+---
+title: "LinkedIn Design System"
+summary: "A design system isn't components — it's the version of the codebase your colleagues actually use."
+tags: ["design-systems", "components", "documentation"]
+date: 2022-08-20
+featured: false
+role: "Design Engineer"
+company: "LinkedIn"
+period: "2020–2023"
+---
+
+> 📝 **Claude draft — pending Luis's review.** Generic framing only; Luis owns
+> the specific decisions and outcomes worth highlighting.
+
+The design system isn't the thing in the docs site. It's the version of the codebase your product engineers actually reach for at 4pm on a Friday when the deadline is Monday. Everything else — the components, the docs, the Figma library — is in service of that one moment.
+
+## Context
+
+LinkedIn at this scale has hundreds of engineers shipping into the same product. Coherence is the default failure mode: ten dropdown menus, twelve toast variants, four spinners that all spin slightly differently. The system's job is to make the coherent choice cheaper than the bespoke one — for the engineer typing at 4pm, not for the system reviewer six weeks later.
+
+## Move
+
+*Skeleton — needs Luis's first-person account:*
+
+- The components you chose to invest in (and what you deliberately left undocumented)
+- The contribution model — how external teams added primitives without forking the system
+- The docs + linter pairing that turned the system from a library into infrastructure
+
+## Outcome
+
+*Skeleton — needs Luis's metrics:*
+
+- Adoption % across the product
+- The pattern-debt audit (what you killed, what you absorbed)
+- The behavioural change you noticed in PR reviews
+
+## What I'd do differently
+
+*Skeleton — needs Luis's retro:*
+
+- The primitive you over-built
+- The doc that should have been a lint rule
+- The signal you'd watch earlier next time

--- a/src/content/work/superhuman-com.mdx
+++ b/src/content/work/superhuman-com.mdx
@@ -1,0 +1,43 @@
+---
+title: "Superhuman.com — from scratch"
+summary: "A marketing site that earns the product's reputation: every frame considered, nothing perfunctory."
+tags: ["marketing-site", "motion", "performance"]
+date: 2024-12-01
+featured: true
+role: "Design Engineer"
+company: "Superhuman"
+period: "2024–present"
+---
+
+> 📝 **Claude draft — pending Luis's review.** Outline only; specific pages /
+> animations / measurements need Luis's first-person account.
+
+Superhuman is a product that signals craft in every micro-interaction. A marketing site that ships at *Marketing-Site Average* would undercut the pitch before the visitor reads it. Building the new superhuman.com meant translating product values — speed, restraint, considered motion — into a presentation surface where those values are the message.
+
+## Context
+
+A new product site for an established brand is a constraint puzzle. The audience already has expectations; the site has to surprise them upward without breaking the recognition contract. Every animation that lands must be deliberate; every animation that loops must justify the loop; every line of copy that earns the click does so because it sounds like the product, not the marketing team.
+
+## Move
+
+*Skeleton — needs Luis's first-person account:*
+
+- The first decision that scoped the rest of the site
+- The motion-budget conversation (what you let yourself animate, what you didn't)
+- How you got the performance numbers honest in a marketing-site context where bloat is the genre default
+
+## Outcome
+
+*Skeleton — needs Luis's launch story:*
+
+- Performance numbers at launch
+- The unexpected piece of feedback from the field
+- The pattern from this project that's leaking into the product surface
+
+## What I'd do differently
+
+*Skeleton — needs Luis's retro:*
+
+- The animation you'd cut
+- The architectural decision you'd revisit
+- The collaboration pattern with the brand / writing team that you'd start earlier

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,19 @@
 ---
 import Base from "~/layouts/Base.astro";
 import HeroName from "~/components/HeroName.astro";
+import WorkCard from "~/components/WorkCard.astro";
+import { getCollection } from "astro:content";
+
+/*
+ * Featured work — limited to 3 entries marked `featured: true` in the
+ * collection. The list is hand-curated via frontmatter rather than ranked
+ * algorithmically; the home page is editorial space.
+ *
+ * LinkedIn Coach surfaces here per ST-4's acceptance criteria.
+ */
+const featured = (await getCollection("work", entry => entry.data.featured && !entry.data.draft))
+  .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
+  .slice(0, 3);
 ---
 
 <Base title="Luis Torres" description="Design engineer building for the web.">
@@ -9,8 +22,7 @@ import HeroName from "~/components/HeroName.astro";
       <!--
         Contribution graph background. ST-3 fills this slot with a build-time
         static SVG of the merged GitHub contribution calendar — feathered
-        radial mask, ~18% opacity, anchored bottom-right. Until then the slot
-        sits empty so the hero composition is fully designed without it.
+        radial mask, ~18% opacity, anchored bottom-right.
       -->
       <div class="hero__graph" aria-hidden="true" data-graph-slot></div>
 
@@ -24,6 +36,21 @@ import HeroName from "~/components/HeroName.astro";
         </p>
       </div>
     </section>
+
+    {featured.length > 0 && (
+      <section class="home__work" aria-labelledby="featured-work-heading">
+        <header class="home__work-head">
+          <p class="home__eyebrow">recent work</p>
+          <h2 id="featured-work-heading" class="home__work-title">Three case studies</h2>
+        </header>
+        <div class="home__work-grid">
+          {featured.map(entry => <WorkCard entry={entry} />)}
+        </div>
+        <p class="home__work-more">
+          <a href="/work">read all case studies →</a>
+        </p>
+      </section>
+    )}
   </main>
 </Base>
 
@@ -32,6 +59,8 @@ import HeroName from "~/components/HeroName.astro";
     max-width: var(--container-wide);
     margin-inline: auto;
     padding: var(--space-7) var(--space-5) var(--space-9);
+    display: grid;
+    gap: var(--space-9);
   }
 
   .hero {
@@ -107,5 +136,55 @@ import HeroName from "~/components/HeroName.astro";
     .hero__stat {
       animation: hero-rise 600ms var(--ease-out-expo) 280ms both;
     }
+  }
+
+  /* "Recent work" — 3 featured cards below the hero. */
+  .home__eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-text-muted);
+    text-transform: lowercase;
+  }
+
+  .home__work {
+    display: grid;
+    gap: var(--space-5);
+  }
+
+  .home__work-head {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .home__work-title {
+    font-family: var(--font-display);
+    font-size: var(--type-28);
+    line-height: var(--line-snug);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-text-default);
+  }
+
+  .home__work-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: var(--space-5);
+  }
+
+  .home__work-more {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .home__work-more a {
+    color: var(--color-action);
+    text-decoration: none;
+  }
+
+  .home__work-more a:hover,
+  .home__work-more a:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
   }
 </style>

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -1,0 +1,167 @@
+---
+import Base from "~/layouts/Base.astro";
+import Prose from "~/components/Prose.astro";
+import { getCollection, render } from "astro:content";
+
+export async function getStaticPaths() {
+  const entries = await getCollection("work");
+  return entries.map(entry => ({
+    params: { slug: entry.id.replace(/\.(md|mdx)$/, "") },
+    props: { entry },
+  }));
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+const { title, summary, role, company, period, tags, date } = entry.data;
+const dateIso = date.toISOString().slice(0, 10);
+---
+
+<Base title={`${title} — Luis Torres`} description={summary}>
+  <article class="case">
+    <header class="case__head">
+      <p class="case__eyebrow">case study</p>
+      <h1 class="case__title">{title}</h1>
+      <p class="case__summary">{summary}</p>
+
+      <dl class="case__meta">
+        {company && (
+          <>
+            <dt>company</dt>
+            <dd>{company}</dd>
+          </>
+        )}
+        {role && (
+          <>
+            <dt>role</dt>
+            <dd>{role}</dd>
+          </>
+        )}
+        {period && (
+          <>
+            <dt>period</dt>
+            <dd>{period}</dd>
+          </>
+        )}
+        <dt>published</dt>
+        <dd><time datetime={dateIso}>{dateIso}</time></dd>
+      </dl>
+    </header>
+
+    <Prose>
+      <Content />
+    </Prose>
+
+    {tags.length > 0 && (
+      <footer class="case__foot">
+        <ul class="case__tags" role="list">
+          {tags.map(tag => (
+            <li class="case__tag">#{tag}</li>
+          ))}
+        </ul>
+        <p class="case__back">
+          <a href="/work">← all case studies</a>
+        </p>
+      </footer>
+    )}
+  </article>
+</Base>
+
+<style>
+  .case {
+    max-width: var(--container-prose);
+    margin-inline: auto;
+    padding: var(--space-8) var(--space-5) var(--space-10);
+  }
+
+  .case__head {
+    display: grid;
+    gap: var(--space-3);
+    padding-block-end: var(--space-7);
+    margin-block-end: var(--space-7);
+    border-block-end: 1px solid var(--color-border);
+  }
+
+  .case__eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-muted);
+    letter-spacing: var(--tracking-wide);
+    text-transform: lowercase;
+  }
+
+  .case__title {
+    font-family: var(--font-display);
+    font-size: var(--type-40);
+    line-height: var(--line-tight);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  .case__summary {
+    color: var(--color-text-muted);
+    font-size: var(--type-21);
+    line-height: var(--line-snug);
+    max-width: 60ch;
+  }
+
+  .case__meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: var(--space-1) var(--space-4);
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    text-transform: lowercase;
+    letter-spacing: var(--tracking-wide);
+    margin-block-start: var(--space-3);
+  }
+
+  .case__meta dt {
+    color: var(--color-text-subtle);
+  }
+
+  .case__meta dd {
+    margin: 0;
+    color: var(--color-text-muted);
+  }
+
+  .case__foot {
+    margin-block-start: var(--space-8);
+    padding-block-start: var(--space-5);
+    border-block-start: 1px solid var(--color-border);
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .case__tags {
+    display: flex;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .case__tag {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    text-transform: lowercase;
+  }
+
+  .case__back {
+    font-family: var(--font-mono);
+    font-size: var(--type-14);
+  }
+
+  .case__back a {
+    color: var(--color-action);
+    text-decoration: none;
+  }
+
+  .case__back a:hover,
+  .case__back a:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+</style>

--- a/src/pages/work/index.astro
+++ b/src/pages/work/index.astro
@@ -1,0 +1,70 @@
+---
+import Base from "~/layouts/Base.astro";
+import WorkCard from "~/components/WorkCard.astro";
+import { getCollection } from "astro:content";
+
+const entries = (await getCollection("work", entry => !entry.data.draft)).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+);
+---
+
+<Base title="Work — Luis Torres" description="Case studies in design engineering — LinkedIn, Superhuman, Grammarly.">
+  <main class="work-index">
+    <header class="work-index__head">
+      <p class="work-index__eyebrow">work</p>
+      <h1 class="work-index__title">Case studies</h1>
+      <p class="work-index__lede">
+        Five projects, each written so the decisions read clearly — what the constraint was, what
+        the move was, what it cost. Every entry ends with <em>what I'd do differently</em>, which
+        is usually the bit worth reading.
+      </p>
+    </header>
+
+    <div class="work-index__grid">
+      {entries.map(entry => <WorkCard entry={entry} />)}
+    </div>
+  </main>
+</Base>
+
+<style>
+  .work-index {
+    max-width: var(--container-wide);
+    margin-inline: auto;
+    padding: var(--space-8) var(--space-5) var(--space-10);
+    display: grid;
+    gap: var(--space-8);
+  }
+
+  .work-index__head {
+    display: grid;
+    gap: var(--space-3);
+    padding-block-end: var(--space-5);
+    border-block-end: 1px solid var(--color-border);
+    max-width: 56ch;
+  }
+
+  .work-index__eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-muted);
+    letter-spacing: var(--tracking-wide);
+    text-transform: lowercase;
+  }
+
+  .work-index__title {
+    font-family: var(--font-display);
+    font-size: var(--type-64);
+    line-height: var(--line-tight);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  .work-index__lede {
+    color: var(--color-text-muted);
+  }
+
+  .work-index__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+    gap: var(--space-5);
+  }
+</style>


### PR DESCRIPTION
## Summary

Lays down the content-collection plumbing the rest of the site reads from, plus five case studies as **MDX skeletons clearly marked as Claude drafts pending your edits** — matches the path called out in PLAN.md Open Questions (\"Claude draft + Luis edit\").

- **\`src/content.config.ts\`**: two collections (\`work\` + \`writing\`) using Astro 5's \`glob\` loader. Zod schemas validate frontmatter at build time — a misshapen MDX file fails \`astro build\` with a clear error.
- **5 case studies as MDX** in priority order: LinkedIn Coach (hero / \`featured: true\`), LinkedIn Dark Mode (\`featured: true\`), LinkedIn Design System, Superhuman.com (\`featured: true\`), Grammarly AI Detector. Each follows the canonical structure (hook + Context + Move + Outcome + What I'd do differently).
- **\`/work\` index** lists all non-draft entries sorted by date desc.
- **\`/work/[...slug]\`** renders each case study — header with title / summary / mono meta-dl, Prose-wrapped body, footer with tags + back link.
- **\`WorkCard.astro\`** is the index cell (hover lifts 2px, reduced motion disables it). **\`Prose.astro\`** wraps long-form MDX with token-derived typographic spacing.
- **Home page** gains a \"Recent work\" section featuring 3 \`featured: true\` entries (LinkedIn Coach, Dark Mode, Superhuman).

## ⚠️ Heads-up: content is intentionally skeletal

Each MDX file opens with a clearly-marked blockquote:

> 📝 Claude draft — pending Luis's review. […]

The **hook** + **Context** sections read cleanly from public-knowledge framing. The **Move**, **Outcome**, and **What I'd do differently** sections are bullet-point skeletons that need your first-person account before they read as your voice rather than a generic case-study template. This matches PLAN.md's recommendation; ship the structure now, fill the content over the following 2 weeks.

## Conflict with #14 (ST-2)

Both this PR and #14 modify \`src/pages/index.astro\`. The two changes are additive in intent but land on the same file:

- #14 (ST-2) replaces the home with the chromatic-split hero + ambient pulse.
- This PR (ST-4) adds a \"Recent work\" section below the (placeholder) hero.

Suggested merge order: **#14 first**, then rebase this PR. The rebase combines:
- ST-2's full hero composition
- ST-4's \`featured\` work fetch + \"Recent work\" section appended after the hero

If you'd rather merge this first, the conflict resolution lifts the \`featured\` fetch + \"Recent work\" section onto #14's branch.

## Acceptance criteria verification

- [x] \`src/content.config.ts\` validates frontmatter at build time — Zod schemas declared; build fails on misshapen MDX. Used Astro 5's \`glob\` loader (the modern replacement for \`type: 'content'\`).
- [x] All 5 case studies render at \`/work/<slug>\` — verified \`dist/work/{linkedin-coach,linkedin-dark-mode,linkedin-design-system,superhuman-com,grammarly-ai-detector}/index.html\` all produced.
- [x] Build-time typecheck passes (\`pnpm run typecheck\` → 0 errors / 0 warnings across 10 .astro files); content collection types inferred from Zod schema (no manual interfaces).
- [x] LinkedIn Coach featured on home as one of 3 work highlights (alongside Dark Mode + Superhuman, all \`featured: true\`).

## Test plan

- [ ] Edit each case-study MDX to fill in the skeleton sections with your voice.
- [ ] Verify the meta-dl on \`/work/<slug>\` reads correctly (company · role · period · published).
- [ ] Walk \`/work\` on a 360px viewport — cards should stack cleanly.
- [ ] Toggle dark mode on \`/work/linkedin-coach\` — blockquote bar (terracotta-60), code-block surface, all read correctly.

## Out of scope (deferred)

- Case-study hero imagery — PLAN.md explicitly defers (\"ship ST-4 with placeholder slots and fill over the following 2 weeks\"). The \`heroImage\` field is optional on the schema.
- \`/writing\` index renders — part of ST-5; only the schema lives here.
- Spanish translations — ST-6.

Closes semanticpixel/theluistorres#16