### PR TITLE
fix(ci): deploy Astro via GitHub Actions, disable Jekyll

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,63 @@
+name: Deploy site to GitHub Pages
+
+# Triggers when master changes and (manually) from the Actions UI.
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+# Pages deploys need both `contents: read` (to clone) and `pages: write` +
+# `id-token: write` (so the deploy step can authenticate against the Pages
+# environment).
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Cancel any in-flight deploy when a newer commit lands — no point publishing
+# a stale build behind the head one.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Astro
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        # Reads packageManager + pnpm-workspace.yaml from the repo — no version
+        # pinned here so the deploy follows what `package.json` declares.
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deploy
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Why

Pages is currently set to **\"Deploy from a branch\"** and the default Jekyll build runs on every push to master. Now that the repo is Astro, Jekyll trips on the \`.astro\` frontmatter blocks and the deploy fails:

\`\`\`
YAML Exception reading src/components/HeroName.astro
YAML Exception reading src/components/Nav.astro
ERROR: YOUR SITE COULD NOT BE BUILT: Invalid YAML front matter in Footer.astro
\`\`\`

The whole site is now Astro, so Pages needs to deploy the built \`dist/\` from a GitHub Actions workflow instead of running Jekyll on the source tree.

## What

- **\`.github/workflows/deploy-pages.yml\`** — builds Astro on push to master (\`pnpm install --frozen-lockfile\` → \`pnpm run build\`), uploads \`dist/\` as the Pages artifact, deploys via \`actions/deploy-pages@v4\`. Concurrency group \`pages\` with \`cancel-in-progress: true\` so a newer commit supersedes an in-flight build.
- **\`public/.nojekyll\`** — belt-and-suspenders. Once Pages source is flipped to \"GitHub Actions\" Jekyll is out of the picture, but this empty file prevents Pages from quietly applying Jekyll filters to Astro's underscored asset paths (\`_astro/…\`).

This is technically ST-9 (cutover) scope, but the Jekyll failure is blocking master right now — small hotfix PR ahead of ST-9 lands the deploy path so subsequent merges (#25, #26, #27) actually publish.

## ⚠️ Manual step you need to do once after merging

**Repo Settings → Pages → Source: change from \"Deploy from a branch\" to \"GitHub Actions\".**

That's the one switch GitHub won't let a workflow flip for you. After it's flipped, every push to master triggers the new workflow and the artifact lands on projectluis.com.

## Test plan

- [ ] Merge this PR.
- [ ] Flip Pages source in repo Settings (one-time manual step above).
- [ ] Re-run / next push to master triggers the new workflow; Actions tab shows \"Deploy site to GitHub Pages\" succeeding.
- [ ] Visit projectluis.com — Astro build is live (hero with chromatic-split name pending once #25 merges, but ST-1 baseline should already be visible from #23).