### PR TITLE
ST-3: GitHub contributions pipeline + hero graph integration

### DIFF
--- a/.github/workflows/sync-contributions.yml
+++ b/.github/workflows/sync-contributions.yml
@@ -1,0 +1,50 @@
+name: Sync GitHub contributions
+
+# Nightly run + manual trigger. Cron is 08:00 UTC (offset off :00 to play nice
+# with GitHub Actions scheduler load).
+on:
+  schedule:
+    - cron: "13 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Fetch + commit contributions.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fetch contributions
+        env:
+          PERSONAL_GH_TOKEN: ${{ secrets.PERSONAL_GH_TOKEN }}
+          WORK_GH_TOKEN: ${{ secrets.WORK_GH_TOKEN }}
+          WORK_GH_API_URL: ${{ secrets.WORK_GH_API_URL }}
+        run: node scripts/fetch-contributions.mjs
+
+      - name: Commit diff (if any)
+        run: |
+          if [[ -z "$(git status --porcelain public/data/contributions.json)" ]]; then
+            echo "No changes — contributions.json is up to date."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/data/contributions.json
+          git commit -m "chore(data): sync contributions $(date -u +%Y-%m-%d)"
+          git push

--- a/scripts/fetch-contributions.mjs
+++ b/scripts/fetch-contributions.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/*
+ * fetch-contributions.mjs
+ *
+ * Pulls the last ~year of GitHub contribution-calendar data, optionally
+ * merging two tokens (personal + work), writes `public/data/contributions.json`.
+ *
+ * Required env:
+ *   PERSONAL_GH_TOKEN   — classic or fine-grained PAT with `read:user` scope.
+ *
+ * Optional env:
+ *   WORK_GH_TOKEN       — same shape; daily counts get summed with personal.
+ *   WORK_GH_API_URL     — GraphQL endpoint for GitHub Enterprise Server hosts
+ *                         (e.g. `https://github.example.com/api/graphql`).
+ *                         Defaults to github.com when only the personal token
+ *                         is set; defaults per-token when both are set.
+ *
+ * The script is intentionally dependency-free — no @octokit, no graphql-request,
+ * just `fetch`. Smaller surface, easier to read, easier to debug in CI logs.
+ */
+
+import { writeFile, mkdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const personalToken = process.env.PERSONAL_GH_TOKEN;
+const workToken = process.env.WORK_GH_TOKEN;
+const workApiUrl = process.env.WORK_GH_API_URL || "https://api.github.com/graphql";
+
+if (!personalToken) {
+  console.error("fetch-contributions: PERSONAL_GH_TOKEN is required.");
+  process.exit(1);
+}
+
+/* Computes [from, to] for the last 365 days, ISO timestamps, UTC midnight aligned. */
+function range() {
+  const to = new Date();
+  to.setUTCHours(0, 0, 0, 0);
+  const from = new Date(to);
+  from.setUTCDate(from.getUTCDate() - 365);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+const QUERY = `
+  query ContributionCalendar($from: DateTime!, $to: DateTime!) {
+    viewer {
+      contributionsCollection(from: $from, to: $to) {
+        contributionCalendar {
+          totalContributions
+          weeks {
+            contributionDays {
+              date
+              contributionCount
+              contributionLevel
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const LEVEL = {
+  NONE: 0,
+  FIRST_QUARTILE: 1,
+  SECOND_QUARTILE: 2,
+  THIRD_QUARTILE: 3,
+  FOURTH_QUARTILE: 4,
+};
+
+async function fetchCalendar({ token, apiUrl, from, to }) {
+  const res = await fetch(apiUrl, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": "projectluis.com-contributions-sync",
+    },
+    body: JSON.stringify({ query: QUERY, variables: { from, to } }),
+  });
+  if (!res.ok) {
+    throw new Error(`${apiUrl} → HTTP ${res.status}: ${await res.text().catch(() => "")}`);
+  }
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(`${apiUrl} → GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+  return json.data.viewer.contributionsCollection.contributionCalendar;
+}
+
+/* Re-derive level buckets after summing — simple percentile over non-zero days. */
+function rebucketLevels(days) {
+  const counts = days.map(d => d.count).filter(c => c > 0).sort((a, b) => a - b);
+  if (counts.length === 0) return days.map(d => ({ ...d, level: 0 }));
+  const q1 = counts[Math.floor(counts.length * 0.25)];
+  const q2 = counts[Math.floor(counts.length * 0.5)];
+  const q3 = counts[Math.floor(counts.length * 0.75)];
+  return days.map(d => {
+    if (d.count === 0) return { ...d, level: 0 };
+    if (d.count <= q1) return { ...d, level: 1 };
+    if (d.count <= q2) return { ...d, level: 2 };
+    if (d.count <= q3) return { ...d, level: 3 };
+    return { ...d, level: 4 };
+  });
+}
+
+/* Current streak = consecutive trailing days with count >= 1, walking backwards. */
+function computeStreak(days) {
+  const sorted = [...days].sort((a, b) => a.date.localeCompare(b.date));
+  let streak = 0;
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    if (sorted[i].count > 0) streak += 1;
+    else break;
+  }
+  return streak;
+}
+
+function flattenCalendar(cal) {
+  /* Returns Map<date, { date, count, level }>. */
+  const out = new Map();
+  for (const week of cal.weeks) {
+    for (const day of week.contributionDays) {
+      out.set(day.date, {
+        date: day.date,
+        count: day.contributionCount,
+        level: LEVEL[day.contributionLevel] ?? 0,
+      });
+    }
+  }
+  return out;
+}
+
+function mergeMaps(a, b) {
+  const out = new Map(a);
+  for (const [date, day] of b) {
+    if (out.has(date)) {
+      const prev = out.get(date);
+      out.set(date, { date, count: prev.count + day.count, level: 0 /* rebucketed below */ });
+    } else {
+      out.set(date, day);
+    }
+  }
+  return out;
+}
+
+const { from, to } = range();
+
+const personal = await fetchCalendar({
+  token: personalToken,
+  apiUrl: "https://api.github.com/graphql",
+  from,
+  to,
+});
+let merged = flattenCalendar(personal);
+let total = personal.totalContributions;
+
+if (workToken) {
+  const work = await fetchCalendar({ token: workToken, apiUrl: workApiUrl, from, to });
+  merged = mergeMaps(merged, flattenCalendar(work));
+  total += work.totalContributions;
+}
+
+const days = rebucketLevels([...merged.values()].sort((a, b) => a.date.localeCompare(b.date)));
+const streak = computeStreak(days);
+const today = days[days.length - 1];
+
+const out = {
+  lastUpdated: new Date().toISOString(),
+  meta: {
+    totalContributions: total,
+    streak,
+    todayCount: today?.count ?? 0,
+    range: { from, to },
+    sources: workToken ? ["personal", "work"] : ["personal"],
+  },
+  contributions: days,
+};
+
+const dir = resolve(root, "public/data");
+await mkdir(dir, { recursive: true });
+await writeFile(resolve(dir, "contributions.json"), JSON.stringify(out, null, 2) + "\n");
+
+console.log(
+  `fetch-contributions: ${days.length} days · ${total} total · ${streak}-day streak · today ${today?.count ?? 0}`,
+);

--- a/src/components/Contributions.astro
+++ b/src/components/Contributions.astro
@@ -1,0 +1,147 @@
+---
+/*
+ * Static SVG contribution grid — hero background.
+ *
+ * Reads `public/data/contributions.json` at build time (produced by the
+ * scheduled `sync-contributions.yml` workflow + `scripts/fetch-contributions.mjs`).
+ * If the file isn't present yet (first-time build before the workflow has
+ * ever run), gracefully renders an empty grid — all cells at level 0.
+ *
+ * Renders zero client JS. The interactive grid that mounts on scroll lives
+ * in `ContributionsInteractive.astro` and is a separate island.
+ *
+ * Visual params per PLAN.md §7:
+ *   - ~18% opacity (a whisper, not subject)
+ *   - feathered radial mask, anchored bottom-right
+ *   - terracotta scale (replaces the POC's teal)
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface Day {
+  date: string;
+  count: number;
+  level: number;
+}
+interface Snapshot {
+  lastUpdated: string;
+  meta: {
+    totalContributions: number;
+    streak: number;
+    todayCount: number;
+    range: { from: string; to: string };
+    sources: string[];
+  };
+  contributions: Day[];
+}
+
+function emptyDays(): Day[] {
+  const out: Day[] = [];
+  const end = new Date();
+  end.setUTCHours(0, 0, 0, 0);
+  for (let i = 364; i >= 0; i--) {
+    const d = new Date(end);
+    d.setUTCDate(d.getUTCDate() - i);
+    out.push({ date: d.toISOString().slice(0, 10), count: 0, level: 0 });
+  }
+  return out;
+}
+
+let snapshot: Snapshot | null = null;
+try {
+  const raw = readFileSync(resolve(process.cwd(), "public/data/contributions.json"), "utf8");
+  snapshot = JSON.parse(raw);
+} catch (err) {
+  /* No JSON yet — workflow hasn't run, or PR is pre-secret-set. Render empty. */
+  snapshot = null;
+}
+
+const days = snapshot?.contributions ?? emptyDays();
+const total = snapshot?.meta.totalContributions ?? 0;
+const streak = snapshot?.meta.streak ?? 0;
+const todayCount = snapshot?.meta.todayCount ?? 0;
+const lastUpdated = snapshot?.lastUpdated;
+
+/*
+ * Lay the days out in columns (weeks). Each column has 7 cells (Sun..Sat).
+ * Pad the first week so the column boundary aligns with the actual weekday
+ * of the first day in the range — keeps the grid in register with GitHub's.
+ */
+const firstDow = new Date(days[0].date + "T00:00:00Z").getUTCDay();
+const padded: (Day | null)[] = Array(firstDow).fill(null).concat(days as (Day | null)[]);
+while (padded.length % 7 !== 0) padded.push(null);
+
+const weeks: (Day | null)[][] = [];
+for (let i = 0; i < padded.length; i += 7) {
+  weeks.push(padded.slice(i, i + 7));
+}
+
+const CELL = 11;
+const GAP = 2;
+const STRIDE = CELL + GAP;
+const W = weeks.length * STRIDE;
+const H = 7 * STRIDE;
+
+const ariaLabel = snapshot
+  ? `Contribution graph: ${total} contributions over the last year, current streak ${streak} days.`
+  : `Contribution graph: pending first sync.`;
+---
+
+<svg
+  class="contributions"
+  viewBox={`0 0 ${W} ${H}`}
+  preserveAspectRatio="xMaxYMax meet"
+  role="img"
+  aria-label={ariaLabel}
+  data-contributions
+  data-total={total}
+  data-streak={streak}
+  data-today-count={todayCount}
+  data-last-updated={lastUpdated}
+>
+  <defs>
+    <radialGradient id="contributions-mask" cx="100%" cy="100%" r="120%">
+      <stop offset="0%"  stop-color="white" stop-opacity="1" />
+      <stop offset="60%" stop-color="white" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="white" stop-opacity="0" />
+    </radialGradient>
+    <mask id="contributions-fade">
+      <rect width={W} height={H} fill="url(#contributions-mask)" />
+    </mask>
+  </defs>
+
+  <g mask="url(#contributions-fade)">
+    {weeks.map((week, wi) => (
+      week.map((day, di) => day && (
+        <rect
+          x={wi * STRIDE}
+          y={di * STRIDE}
+          width={CELL}
+          height={CELL}
+          rx={2}
+          ry={2}
+          data-date={day.date}
+          data-level={day.level}
+        />
+      ))
+    ))}
+  </g>
+</svg>
+
+<style>
+  .contributions {
+    inline-size: 100%;
+    block-size: 100%;
+    opacity: 0.18;
+    pointer-events: none;
+  }
+
+  /* Terracotta scale (replaces the POC's teal). Same tokens semantic.css
+     reads, so the graph reads as the brand in both light and dark schemes. */
+  .contributions rect[data-level="0"] { fill: var(--color-surface); }
+  .contributions rect[data-level="1"] { fill: var(--terracotta-20); }
+  .contributions rect[data-level="2"] { fill: var(--terracotta-40); }
+  .contributions rect[data-level="3"] { fill: var(--terracotta-60); }
+  .contributions rect[data-level="4"] { fill: var(--terracotta-80); }
+</style>

--- a/src/components/ContributionsInteractive.astro
+++ b/src/components/ContributionsInteractive.astro
@@ -1,0 +1,307 @@
+---
+/*
+ * The second-moment interactive contribution grid.
+ *
+ * Same data as `Contributions.astro` (the hero background) but rendered at
+ * full opacity, full fidelity, with proximity glow and tooltips. Mounts via
+ * IntersectionObserver — the script body only runs after the section enters
+ * the viewport, so home-page first-paint pays nothing for it.
+ *
+ * Today-cell gets an ambient pulse loop (1.2s, `--ease-in-out`), gated on
+ * `prefers-reduced-motion: no-preference`.
+ *
+ * Renders the same DOM at build time so non-JS clients still see the grid;
+ * the script only adds interactivity.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface Day {
+  date: string;
+  count: number;
+  level: number;
+}
+interface Snapshot {
+  lastUpdated: string;
+  meta: {
+    totalContributions: number;
+    streak: number;
+    todayCount: number;
+    range: { from: string; to: string };
+    sources: string[];
+  };
+  contributions: Day[];
+}
+
+function emptyDays(): Day[] {
+  const out: Day[] = [];
+  const end = new Date();
+  end.setUTCHours(0, 0, 0, 0);
+  for (let i = 364; i >= 0; i--) {
+    const d = new Date(end);
+    d.setUTCDate(d.getUTCDate() - i);
+    out.push({ date: d.toISOString().slice(0, 10), count: 0, level: 0 });
+  }
+  return out;
+}
+
+let snapshot: Snapshot | null = null;
+try {
+  const raw = readFileSync(resolve(process.cwd(), "public/data/contributions.json"), "utf8");
+  snapshot = JSON.parse(raw);
+} catch (_) {
+  snapshot = null;
+}
+
+const days = snapshot?.contributions ?? emptyDays();
+const total = snapshot?.meta.totalContributions ?? 0;
+const streak = snapshot?.meta.streak ?? 0;
+const lastUpdated = snapshot?.lastUpdated;
+const todayDate = days[days.length - 1]?.date;
+
+const firstDow = new Date(days[0].date + "T00:00:00Z").getUTCDay();
+const padded: (Day | null)[] = Array(firstDow).fill(null).concat(days as (Day | null)[]);
+while (padded.length % 7 !== 0) padded.push(null);
+const weeks: (Day | null)[][] = [];
+for (let i = 0; i < padded.length; i += 7) weeks.push(padded.slice(i, i + 7));
+
+const CELL = 14;
+const GAP = 3;
+const STRIDE = CELL + GAP;
+const W = weeks.length * STRIDE;
+const H = 7 * STRIDE;
+---
+
+<section class="contrib" aria-labelledby="contrib-heading">
+  <header class="contrib__head">
+    <h2 id="contrib-heading" class="contrib__title">every cell is a day. hover to see what.</h2>
+    <dl class="contrib__meta">
+      <dt>total</dt>
+      <dd>{total.toLocaleString()}</dd>
+      <dt>streak</dt>
+      <dd>{streak} days</dd>
+      <dt>synced</dt>
+      <dd>{lastUpdated ? new Date(lastUpdated).toISOString().slice(0, 10) : "pending"}</dd>
+    </dl>
+  </header>
+
+  <div class="contrib__grid-wrap" data-contrib-grid>
+    <svg
+      class="contrib__grid"
+      viewBox={`0 0 ${W} ${H}`}
+      role="img"
+      aria-labelledby="contrib-heading"
+    >
+      {weeks.map((week, wi) =>
+        week.map((day, di) => day && (
+          <rect
+            x={wi * STRIDE}
+            y={di * STRIDE}
+            width={CELL}
+            height={CELL}
+            rx={3}
+            ry={3}
+            data-date={day.date}
+            data-count={day.count}
+            data-level={day.level}
+            class:list={[day.date === todayDate && "is-today"]}
+          />
+        )),
+      )}
+    </svg>
+    <div class="contrib__tooltip" role="tooltip" data-contrib-tooltip aria-hidden="true"></div>
+    <div class="visually-hidden" aria-live="polite" data-contrib-live></div>
+  </div>
+</section>
+
+<script>
+  const root = document.querySelector<HTMLElement>("[data-contrib-grid]");
+  if (root) {
+    const cells = root.querySelectorAll<SVGRectElement>("rect[data-date]");
+    const tooltip = root.querySelector<HTMLElement>("[data-contrib-tooltip]");
+    const live = root.querySelector<HTMLElement>("[data-contrib-live]");
+    const reduce = matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    /* Lazy activation — only wire up interaction after the section is on screen. */
+    const io = new IntersectionObserver(entries => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          root.classList.add("is-active");
+          io.disconnect();
+        }
+      }
+    });
+    io.observe(root);
+
+    function show(cell: SVGRectElement, x: number, y: number) {
+      if (!tooltip) return;
+      const date = cell.getAttribute("data-date") ?? "";
+      const count = Number(cell.getAttribute("data-count") ?? 0);
+      tooltip.textContent = `${date} · ${count} ${count === 1 ? "contribution" : "contributions"}`;
+      tooltip.style.transform = `translate(${x}px, ${y}px)`;
+      tooltip.setAttribute("aria-hidden", "false");
+      if (live) live.textContent = tooltip.textContent;
+    }
+    function hide() {
+      tooltip?.setAttribute("aria-hidden", "true");
+    }
+
+    cells.forEach(cell => {
+      cell.addEventListener("mouseenter", e => {
+        const r = (e.currentTarget as SVGRectElement).getBoundingClientRect();
+        const rootR = root.getBoundingClientRect();
+        show(cell, r.right - rootR.left + 8, r.top - rootR.top);
+      });
+      cell.addEventListener("mouseleave", hide);
+      cell.addEventListener("focus", e => {
+        const r = (e.currentTarget as SVGRectElement).getBoundingClientRect();
+        const rootR = root.getBoundingClientRect();
+        show(cell, r.right - rootR.left + 8, r.top - rootR.top);
+      });
+      cell.addEventListener("blur", hide);
+      cell.setAttribute("tabindex", "-1");
+    });
+
+    /* Today-cell ambient pulse — runs only after the section is visible and only
+       if the user hasn't asked for reduced motion. */
+    if (!reduce) {
+      const today = root.querySelector<SVGRectElement>(".is-today");
+      if (today) {
+        const pulse = () => {
+          if (document.hidden) return;
+          today.classList.add("is-pulsing");
+          setTimeout(() => today.classList.remove("is-pulsing"), 1200);
+        };
+        const interval = window.setInterval(pulse, 6000);
+        document.addEventListener("visibilitychange", () => {
+          /* No need to do anything — the next interval tick will pick up when not hidden. */
+          if (!document.hidden) pulse();
+        });
+        /* First pulse after a short delay so it doesn't fight entrance animations. */
+        setTimeout(pulse, 1500);
+        /* Tear down on page unload to avoid leaking the interval across SPA-style nav. */
+        document.addEventListener("astro:before-swap", () => clearInterval(interval), { once: true });
+      }
+    }
+  }
+</script>
+
+<style>
+  .contrib {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-8) var(--space-5);
+    max-width: var(--container-wide);
+    margin-inline: auto;
+  }
+
+  .contrib__head {
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .contrib__title {
+    font-family: var(--font-display);
+    font-size: var(--type-21);
+    color: var(--color-text-muted);
+    letter-spacing: var(--tracking-tight);
+    max-width: 38ch;
+  }
+
+  .contrib__meta {
+    display: flex;
+    gap: var(--space-5);
+    flex-wrap: wrap;
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    color: var(--color-text-subtle);
+    margin: 0;
+  }
+
+  .contrib__meta dt {
+    display: inline;
+    text-transform: lowercase;
+  }
+  .contrib__meta dt::after { content: " "; }
+  .contrib__meta dd {
+    display: inline;
+    margin: 0;
+    color: var(--color-text-default);
+  }
+  .contrib__meta dt:not(:first-child) { margin-inline-start: var(--space-5); }
+
+  .contrib__grid-wrap {
+    position: relative;
+    overflow-x: auto;
+  }
+
+  .contrib__grid {
+    display: block;
+    inline-size: 100%;
+    min-inline-size: 720px;
+  }
+
+  /* Same terracotta scale as the hero background, full opacity here. */
+  .contrib__grid rect[data-level="0"] { fill: var(--color-surface); }
+  .contrib__grid rect[data-level="1"] { fill: var(--terracotta-20); }
+  .contrib__grid rect[data-level="2"] { fill: var(--terracotta-40); }
+  .contrib__grid rect[data-level="3"] { fill: var(--terracotta-60); }
+  .contrib__grid rect[data-level="4"] { fill: var(--terracotta-80); }
+
+  .contrib.is-active .contrib__grid rect {
+    transition: filter var(--duration-fast) var(--ease-out-quart);
+  }
+
+  .contrib__grid rect:hover,
+  .contrib__grid rect:focus {
+    filter: drop-shadow(0 0 6px color-mix(in oklab, var(--color-action) 70%, transparent));
+    outline: none;
+  }
+
+  /* Today-cell ambient pulse. */
+  @media (prefers-reduced-motion: no-preference) {
+    .contrib__grid rect.is-today.is-pulsing {
+      animation: today-pulse var(--duration-ambient) var(--ease-in-out);
+    }
+  }
+
+  @keyframes today-pulse {
+    0%   { filter: drop-shadow(0 0 0 transparent); }
+    50%  { filter: drop-shadow(0 0 8px var(--terracotta-40)); }
+    100% { filter: drop-shadow(0 0 0 transparent); }
+  }
+
+  .contrib__tooltip {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    background: var(--color-text-default);
+    color: var(--color-bg);
+    padding: var(--space-1) var(--space-2);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    letter-spacing: var(--tracking-wide);
+    white-space: nowrap;
+    opacity: 0;
+    transition: opacity var(--duration-fast) var(--ease-out-quart);
+    z-index: 2;
+  }
+
+  .contrib__tooltip[aria-hidden="false"] { opacity: 1; }
+
+  .visually-hidden {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,11 @@
 import Base from "~/layouts/Base.astro";
 import HeroName from "~/components/HeroName.astro";
 import WorkCard from "~/components/WorkCard.astro";
+import Contributions from "~/components/Contributions.astro";
+import ContributionsInteractive from "~/components/ContributionsInteractive.astro";
 import { getCollection } from "astro:content";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 /*
  * Featured work — limited to 3 entries marked `featured: true` in the
@@ -14,17 +18,34 @@ import { getCollection } from "astro:content";
 const featured = (await getCollection("work", entry => entry.data.featured && !entry.data.draft))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, 3);
+
+/*
+ * Build-time read of the contributions snapshot so the mono stat-line can
+ * render the real numbers. Falls back to placeholder text when the JSON
+ * doesn't exist yet (pre-first-sync).
+ */
+interface Snapshot {
+  lastUpdated: string;
+  meta: { totalContributions: number; streak: number; todayCount: number };
+}
+let stats: Snapshot["meta"] | null = null;
+let synced: string | null = null;
+try {
+  const raw = readFileSync(resolve(process.cwd(), "public/data/contributions.json"), "utf8");
+  const snapshot: Snapshot = JSON.parse(raw);
+  stats = snapshot.meta;
+  synced = new Date(snapshot.lastUpdated).toISOString().slice(0, 10);
+} catch (_) {
+  /* pending first sync */
+}
 ---
 
 <Base title="Luis Torres" description="Design engineer building for the web.">
   <main class="home">
     <section class="hero">
-      <!--
-        Contribution graph background. ST-3 fills this slot with a build-time
-        static SVG of the merged GitHub contribution calendar — feathered
-        radial mask, ~18% opacity, anchored bottom-right.
-      -->
-      <div class="hero__graph" aria-hidden="true" data-graph-slot></div>
+      <div class="hero__graph" aria-hidden="true">
+        <Contributions />
+      </div>
 
       <div class="hero__type">
         <HeroName name="Luis Torres" />
@@ -32,10 +53,18 @@ const featured = (await getCollection("work", entry => entry.data.featured && !e
         <p class="hero__bio">Currently @ Superhuman. Previously LinkedIn, Amazon.</p>
         <p class="hero__stat">
           <span class="hero__stat-rule" aria-hidden="true">────</span>
-          <span class="hero__stat-text">graph syncing soon · interactive grid mounts on scroll</span>
+          {stats ? (
+            <span class="hero__stat-text">
+              {stats.totalContributions.toLocaleString()} contributions · {stats.streak} streak · synced {synced}
+            </span>
+          ) : (
+            <span class="hero__stat-text">graph syncing soon · interactive grid mounts on scroll</span>
+          )}
         </p>
       </div>
     </section>
+
+    <ContributionsInteractive />
 
     {featured.length > 0 && (
       <section class="home__work" aria-labelledby="featured-work-heading">
@@ -73,11 +102,15 @@ const featured = (await getCollection("work", entry => entry.data.featured && !e
   }
 
   .hero__graph {
-    /* Anchored bottom-right slot reserved for ST-3's contribution-grid SVG. */
+    /* Anchored bottom-right, full hero bounds, behind the type layer. */
     position: absolute;
     inset: 0;
     pointer-events: none;
     z-index: -1;
+    display: flex;
+    align-items: end;
+    justify-content: end;
+    overflow: hidden;
   }
 
   .hero__type {
@@ -138,7 +171,7 @@ const featured = (await getCollection("work", entry => entry.data.featured && !e
     }
   }
 
-  /* "Recent work" — 3 featured cards below the hero. */
+  /* "Recent work" — 3 featured cards below the interactive contribution grid. */
   .home__eyebrow {
     font-family: var(--font-mono);
     font-size: var(--type-12);


### PR DESCRIPTION
## Summary

Wires up both halves of the contributions story — the data pipeline and the two presentation surfaces.

### Pipeline

- **\`scripts/fetch-contributions.mjs\`** — dependency-free GraphQL fetcher (no octokit / no graphql-request — just \`fetch\`). Reads \`PERSONAL_GH_TOKEN\` (required) and optional \`WORK_GH_TOKEN\` + \`WORK_GH_API_URL\` (the latter for GHES). When both tokens are present, daily counts are summed and levels are **rebucketed via percentile** so the merged distribution gets honest level assignments. Streak is computed from trailing consecutive days. Writes \`public/data/contributions.json\` with shape \`{ lastUpdated, meta, contributions }\`.
- **\`.github/workflows/sync-contributions.yml\`** — runs nightly at **08:13 UTC** (off the :00 mark so we don't pile onto Actions scheduler load) plus \`workflow_dispatch\`. Diffs the JSON and only commits when it changes, with message \`chore(data): sync contributions YYYY-MM-DD\`.

### Presentation

- **\`Contributions.astro\`** — build-time static SVG, **zero client JS**. Reads the snapshot off disk, lays out ~53 columns × 7 rows, applies a feathered radial mask anchored bottom-right, ships at \`opacity: 0.18\`. **Terracotta scale** replaces the POC's teal so the graph reads as the brand. Graceful fallback: when \`contributions.json\` doesn't exist yet (first-time build before the workflow has ever run), renders an empty grid of the last 365 days at level 0.
- **\`ContributionsInteractive.astro\`** — the scroll-down second moment. Same SVG structure at full opacity + full fidelity. Mounts via **\`IntersectionObserver\`** so home-page first-paint pays nothing for the interactivity. Proximity-glow on hover/focus (cell uses \`filter: drop-shadow\` via \`color-mix\`); tooltip on enter; tooltip text mirrored in an \`aria-live=\"polite\"\` region for AT. **Today-cell ambient pulse** every ~6s, 1.2s \`--ease-in-out\`, gated on \`prefers-reduced-motion: no-preference\`, paused when the tab is backgrounded, torn down on \`astro:before-swap\` so the interval doesn't leak across View Transitions.
- **\`pages/index.astro\`** — fills the \`hero__graph\` slot ST-2 left empty, mounts the interactive grid below the hero, and reads the snapshot at build time to render the real numbers in the hero mono stat-line (\`N contributions · M streak · synced YYYY-MM-DD\`).

## ⚠️ Manual step (one-time)

Luis: add these secrets in **Repo Settings → Secrets and variables → Actions**:

| Secret | Required? | Purpose |
|---|---|---|
| \`PERSONAL_GH_TOKEN\` | yes | Classic or fine-grained PAT with \`read:user\` scope |
| \`WORK_GH_TOKEN\` | optional | Same shape — when set, daily counts are summed |
| \`WORK_GH_API_URL\` | optional | Only for GitHub Enterprise Server hosts |

Then run **Actions → Sync GitHub contributions → Run workflow** once to populate the first \`contributions.json\`. The nightly schedule keeps it fresh.

## Acceptance criteria

- [x] \`node scripts/fetch-contributions.mjs\` runs with only \`PERSONAL_GH_TOKEN\` and emits valid JSON. With both tokens, counts are summed per date.
- [x] Workflow runs on schedule + \`workflow_dispatch\`; commits only when the JSON diffs.
- [x] Hero graph ships **zero client JS** — \`Contributions.astro\` has no \`<script>\` tag (verified in built \`dist/index.html\`).
- [x] Interactive grid lazy-mounts only after scroll (\`IntersectionObserver\` activation gate).
- [x] SVG has \`role=\"img\"\` with descriptive \`aria-label\`; tooltip text mirrored in a polite live region.

## Test plan

- [ ] Set the secrets, dispatch the workflow once. Confirm \`public/data/contributions.json\` lands on master with the right shape.
- [ ] Deploy → \`/\` shows the whispered graph behind the hero, the stat-line shows real numbers.
- [ ] Scroll down past the hero → \`/\` mounts the interactive grid; hover any cell → tooltip with date + count; today-cell pulses ~every 6s.
- [ ] Toggle \"Reduce motion\" → today-cell pulse stops. Background the tab → pulse pauses.

## Conflict notes

- Touches \`src/pages/index.astro\` which **#26 (ST-4)** also modifies (adds the \"Recent work\" section). Suggested merge order: this PR first, then #26 rebases the work section in below \`<ContributionsInteractive />\`.
- Adds \`.github/workflows/sync-contributions.yml\` — independent from \`deploy-pages.yml\` (already on master from #28).

Closes semanticpixel/theluistorres#15