### PR TITLE
ST-5: /about + /writing + /colophon

### DIFF
--- a/src/content/writing/ui-gems-archive.mdx
+++ b/src/content/writing/ui-gems-archive.mdx
@@ -1,0 +1,8 @@
+---
+title: "UI Gems archive"
+summary: "Index of the full UI Gems back-catalog — every note, every pattern, every small thing worth pointing at. Updated as new entries land."
+externalUrl: "https://ui-gems.com/archive"
+date: 2024-06-01
+readingTime: "varies"
+tags: ["index"]
+---

--- a/src/content/writing/why-ui-gems.mdx
+++ b/src/content/writing/why-ui-gems.mdx
@@ -1,0 +1,8 @@
+---
+title: "Why UI Gems"
+summary: "Notes on the small interactions that make an interface feel hand-built — the patterns worth pointing at, the patterns worth stealing."
+externalUrl: "https://ui-gems.com"
+date: 2024-01-15
+readingTime: "5 min"
+tags: ["intro", "patterns"]
+---

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,0 +1,123 @@
+---
+import Base from "~/layouts/Base.astro";
+import Prose from "~/components/Prose.astro";
+
+const beliefs = [
+  "A design system is a *negotiation*, not a deliverable.",
+  "The CSS cascade is a feature. Lean into it.",
+  "Dark mode isn't a color flip — it's a re-derivation.",
+  "\"It's just CSS\" usually means \"I haven't read the spec recently.\"",
+  "Prefer one strong signal color over five medium ones.",
+  "I learn every day.",
+];
+
+const timeline = [
+  { period: "2024 — present", role: "Design Engineer · Superhuman" },
+  { period: "2023", role: "AI experiments · Grammarly" },
+  { period: "2018 — 2023", role: "Design Systems / Infrastructure UX · LinkedIn" },
+  { period: "Earlier", role: "Conversational UI · Amazon" },
+];
+---
+
+<Base title="About — Luis Torres" description="Design engineer. I write code that pretends not to be there.">
+  <main class="about">
+    <Prose>
+      <h1>About</h1>
+
+      <p class="about__lede">I'm Luis. I write code that pretends not to be there.</p>
+
+      <p>
+        At LinkedIn in 2018, I helped found the Infrastructure UX team. We had a problem most
+        product teams have but few teams <em>own</em>: every product was reinventing the same five
+        buttons in slightly incompatible ways, and a brand refresh meant a six-month parade of pull
+        requests across every consumer surface. The fix wasn't more components. The fix was changing
+        how we thought about color.
+      </p>
+
+      <p>
+        I championed a mindset shift across the org — from <strong>thinking in colors</strong>
+        ("this button is blue") to <strong>thinking in semantics</strong> ("this button uses
+        <code>--color-action-primary</code>"). It sounds small. It's the difference between a brand
+        refresh that takes six months and one that takes an afternoon. It's the difference between a
+        dark mode that ships as an invert and one that <em>re-derives</em> every surface from
+        semantic tokens. It's the difference between a design system you maintain and one that
+        maintains itself.
+      </p>
+
+      <p>
+        That thesis has shaped every design system I've touched since — LinkedIn's component
+        library, Superhuman.com from scratch, the Grammarly experiments.
+      </p>
+
+      <h2>Beliefs, opinion-strong</h2>
+
+      <ul>
+        {beliefs.map(b => <li set:html={b} />)}
+      </ul>
+
+      <h2>Timeline</h2>
+
+      <dl class="about__timeline">
+        {timeline.map(t => (
+          <>
+            <dt>{t.period}</dt>
+            <dd>{t.role}</dd>
+          </>
+        ))}
+      </dl>
+
+      <h2>Mentorship</h2>
+
+      <p>
+        Some of the most rewarding work I do is the work that compounds through other people. I've
+        mentored interns at LinkedIn who became full-time hires, and I'm currently working with two
+        apprentices on the path from junior to mid. Player-coach is the role I'm always growing
+        into.
+      </p>
+
+      <h2>AI tooling I ship</h2>
+
+      <p>
+        I also build small open-source tools that make designers + engineers faster. Most are MCP
+        servers + Claude skills — see <a href="/colophon#ai-powered-tooling">/colophon →
+        AI-powered tooling</a> for the index. The pattern: a problem I hit twice on a Tuesday
+        becomes an open-source package by Friday.
+      </p>
+    </Prose>
+  </main>
+</Base>
+
+<style>
+  .about {
+    padding: var(--space-8) var(--space-5) var(--space-10);
+  }
+
+  .about :global(.prose) :global(.about__lede) {
+    font-family: var(--font-display);
+    font-size: var(--type-28);
+    line-height: var(--line-snug);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-text-default);
+    margin-block-end: var(--space-6);
+  }
+
+  .about :global(.prose) :global(.about__timeline) {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: var(--space-2) var(--space-5);
+    font-family: var(--font-mono);
+    font-size: var(--type-14);
+    margin-block: var(--space-4);
+  }
+
+  .about :global(.prose) :global(.about__timeline dt) {
+    color: var(--color-text-subtle);
+    text-transform: lowercase;
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .about :global(.prose) :global(.about__timeline dd) {
+    margin: 0;
+    color: var(--color-text-default);
+  }
+</style>

--- a/src/pages/colophon.astro
+++ b/src/pages/colophon.astro
@@ -1,0 +1,301 @@
+---
+import Base from "~/layouts/Base.astro";
+import Prose from "~/components/Prose.astro";
+---
+
+<Base
+  title="Colophon — Luis Torres"
+  description="Architecture decisions and rationale — every load-bearing call that shaped this site, written down."
+  transitions={false}
+>
+  <main class="colophon">
+    <Prose>
+      <h1>Colophon</h1>
+
+      <p class="colophon__lede">
+        This is the architecture-decisions log. Every load-bearing choice that shaped the site,
+        with the rationale next to it. Read it the way you'd read a senior engineer's design doc —
+        the *why* is the interesting part.
+      </p>
+
+      <nav class="colophon__toc" aria-label="On this page">
+        <ol>
+          <li><a href="#why-this-site-exists">1. Why this site exists</a></li>
+          <li><a href="#stack">2. Stack</a></li>
+          <li><a href="#content-model">3. Content model</a></li>
+          <li><a href="#design-token-architecture">4. Design token architecture</a></li>
+          <li><a href="#color-modes">5. Color modes</a></li>
+          <li><a href="#accessibility-commitments">6. Accessibility commitments</a></li>
+          <li><a href="#performance-budgets">7. Performance budgets</a></li>
+          <li><a href="#localization-model">8. Localization model</a></li>
+          <li><a href="#ai-powered-tooling">9. AI-powered tooling</a></li>
+          <li><a href="#what-id-do-at-production-scale">10. What I'd do at production scale</a></li>
+          <li><a href="#colophon">11. Colophon (literal)</a></li>
+        </ol>
+      </nav>
+
+      <h2 id="why-this-site-exists">1. Why this site exists</h2>
+
+      <p>
+        A personal site for a design engineer should be the thing itself — every architectural
+        decision visible in the source, every interaction considered, every constraint named.
+        The brief I gave myself: build the site I'd want to read if I were trying to hire me.
+        That meant prose over portfolio bullets, opinions over feature lists, and a colophon
+        long enough to be load-bearing.
+      </p>
+
+      <h2 id="stack">2. Stack</h2>
+
+      <p>
+        <strong>Astro 5</strong>, TypeScript strict, MDX, sitemap, View Transitions. Static
+        output, zero JS by default — every interactive surface opts in as a vanilla TS island
+        with a measured budget. I picked Astro over Next.js deliberately: the site is content,
+        not application; islands beat hydration for surfaces this small; the "static-first,
+        opt-in dynamic" posture matches the way I think about most marketing sites. The cases
+        where I'd reach for Next.js — Server Actions, RSC streaming, middleware-heavy routing —
+        aren't in evidence here.
+      </p>
+
+      <p>
+        Package manager: <strong>pnpm</strong>, pinned via <code>packageManager</code> + Corepack.
+        Content-addressable store, strict peer-dep resolution, faster CI installs. Lockfile is
+        single source of truth.
+      </p>
+
+      <h2 id="content-model">3. Content model</h2>
+
+      <p>
+        Two content collections — <code>work</code> and <code>writing</code> — defined in
+        <code>src/content.config.ts</code> via Astro 5's <code>glob</code> loader. Frontmatter
+        is validated at build time by Zod, so a misshapen MDX file fails <code>astro build</code>
+        with a clear error rather than failing silently in a template at runtime. The shape:
+      </p>
+
+      <pre><code>{`const work = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/work" }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string().min(1),
+      summary: z.string().min(1).max(280),
+      heroImage: image().optional(),
+      tags: z.array(z.string()).default([]),
+      date: z.coerce.date(),
+      featured: z.boolean().default(false),
+      role: z.string().optional(),
+      company: z.string().optional(),
+      period: z.string().optional(),
+    }),
+});`}</code></pre>
+
+      <p>
+        This is the headless-CMS-thinking artifact. The schema is the contract — anything that
+        consumes a case study (the index, the home page, OG generation, future search) reads
+        from the same types. Tomorrow's Payload / Sanity / Contentful migration is a loader
+        swap, not a rewrite.
+      </p>
+
+      <h2 id="design-token-architecture">4. Design token architecture</h2>
+
+      <p>
+        Three layers: <strong>primitives → semantic → component</strong>. Primitives are raw
+        hex (<code>--terracotta-60: #c2625e</code>), semantic tokens consume primitives via
+        <code>light-dark()</code> (<code>--color-action: var(--terracotta-60)</code>), components
+        consume semantic. There is no <code>--blue-</code> anywhere in the codebase — a button
+        doesn't ask for blue, it asks for "action." That's the "thinking in colors → thinking
+        in semantics" thesis, in code.
+      </p>
+
+      <p>
+        Cascade is layered <code>@layer reset, theme, base, components, atoms;</code> — same
+        dialect as my open-source <a href="https://github.com/semanticpixel/trellis">Trellis</a>
+        starter so the vocabulary reads across both codebases.
+      </p>
+
+      <h2 id="color-modes">5. Color modes</h2>
+
+      <p>
+        Three preferences, one token model:
+      </p>
+
+      <ul>
+        <li><code>prefers-color-scheme</code> — resolved via <code>light-dark()</code> on every
+        semantic token. No <code>[data-theme]</code> selectors duplicating values.</li>
+        <li><code>prefers-contrast: more</code> — tightens text/bg to near-black/white and
+        strengthens borders. Same tokens, different resolved values.</li>
+        <li><code>forced-colors: active</code> — hands control to the OS via system color
+        keywords (<code>Canvas</code>, <code>CanvasText</code>, <code>LinkText</code>,
+        <code>Highlight</code>). Tested under Windows High Contrast.</li>
+      </ul>
+
+      <p>
+        All three live in <code>src/styles/theme/semantic.css</code>. Adding a new surface
+        means writing one set of declarations; the four modes resolve automatically.
+      </p>
+
+      <h2 id="accessibility-commitments">6. Accessibility commitments</h2>
+
+      <ul>
+        <li>Keyboard reachable on every interactive surface. Visible <code>:focus-visible</code>
+        ring in <code>--color-focus</code>. No mouse-only affordances.</li>
+        <li>SVG content gets <code>role="img"</code> + descriptive <code>aria-label</code>.
+        Tooltips mirror into <code>aria-live="polite"</code> regions.</li>
+        <li>Every animation is gated on <code>prefers-reduced-motion: no-preference</code>,
+        and reduced-motion is the default in CI's Lighthouse runs.</li>
+        <li>Color contrast minimums met against both light and dark backgrounds (tested via
+        axe-core in CI when ST-8 lands).</li>
+        <li>Semantic HTML first: <code>&lt;nav&gt;</code>, <code>&lt;main&gt;</code>,
+        <code>&lt;article&gt;</code>, real <code>&lt;time datetime&gt;</code> elements, real
+        <code>&lt;button type&gt;</code> on every clickable.</li>
+      </ul>
+
+      <h2 id="performance-budgets">7. Performance budgets</h2>
+
+      <p>
+        Targets, enforced (or about to be — CI gate lands in ST-8):
+      </p>
+
+      <ul>
+        <li><strong>LCP</strong> &lt; 1.5s</li>
+        <li><strong>INP</strong> &lt; 100ms</li>
+        <li><strong>CLS</strong> &lt; 0.02</li>
+        <li><strong>Home JS</strong> &lt; 8 KB gzipped</li>
+        <li><strong>Home CSS</strong> &lt; 12 KB gzipped</li>
+      </ul>
+
+      <p>
+        Currently: home ships one external JS chunk (Astro's ClientRouter for View Transitions,
+        ~5.3 KB gz) plus small inline scripts (theme toggle, hero pulse). Fonts are self-hosted
+        woff2, subset to Latin + Latin-extended only — exactly six woff2 files in the bundle.
+      </p>
+
+      <h2 id="localization-model">8. Localization model</h2>
+
+      <p>
+        Astro's native i18n routing, English default + Spanish at <code>/es</code>. Content is
+        per-locale in sibling collections (<code>work</code> + <code>work-es</code>) — a Spanish
+        page is a real translation, not an injected dictionary lookup. Pages without a Spanish
+        version fall back to English behind a visible ribbon ("Esta página aún no está traducida
+        — mostrando la versión en inglés") so a reader is never silently served the wrong
+        language. The locale switcher preserves the current pathname across switches.
+      </p>
+
+      <p>
+        Spanish ships at launch as a craft demonstration, not as a market move — translating my
+        own work into my own heritage language is something I should be doing regardless.
+      </p>
+
+      <h2 id="ai-powered-tooling">9. AI-powered tooling</h2>
+
+      <p>
+        I ship small open-source tools — mostly MCP servers + Claude skills — that make
+        designers and engineers faster. The pattern: a problem I hit twice on a Tuesday becomes
+        an open-source package by Friday. The link-out index lives here.
+      </p>
+
+      <p>
+        <em>This section is intentionally minimal until I confirm with myself which repos
+        belong on the public list. The scaffold reads from a frontmatter-fed JSON; tomorrow's
+        commit replaces this paragraph with the rendered list, README excerpts pulled at
+        build time, install snippets where applicable.</em>
+      </p>
+
+      <h2 id="what-id-do-at-production-scale">10. What I'd do at production scale</h2>
+
+      <p>
+        Honest list of "this is a portfolio, here's how it would change for Anthropic-scale":
+      </p>
+
+      <ul>
+        <li><strong>Headless CMS</strong> — Payload or Sanity, with the Zod schemas mapped to
+        their type systems. Editorial workflow with preview environments, scheduled publishes,
+        author-driven revisions.</li>
+        <li><strong>Real observability</strong> — RUM (Real User Monitoring), error tracking,
+        a perf budget dashboard that fires alerts when LCP drifts. Sentry or Datadog.</li>
+        <li><strong>CDN strategy</strong> — edge caching with stale-while-revalidate, per-route
+        cache rules, signed URLs for previews.</li>
+        <li><strong>Internationalization vendor</strong> — TMS integration (Phrase, Lokalise) so
+        translators see strings in context, not in spreadsheets.</li>
+        <li><strong>Design-system release pipeline</strong> — semver, changelog, release notes
+        per package, codemods for breaking changes.</li>
+        <li><strong>A11y in CI as a hard gate</strong> — not just axe-core green, but
+        accessibility-tree diffs against a baseline, screen-reader walkthroughs scripted
+        with NVDA + VoiceOver in CI.</li>
+      </ul>
+
+      <h2 id="colophon">11. Colophon (literal)</h2>
+
+      <p>
+        Built in <a href="https://astro.build">Astro 5</a>. Type set in
+        <a href="https://fonts.google.com/specimen/Fraunces">Fraunces</a> (display) +
+        <a href="https://rsms.me/inter/">Inter</a> (body); numerals + metadata in
+        <a href="https://www.jetbrains.com/lp/mono/">JetBrains Mono</a>. Self-hosted, OFL.
+        Source on <a href="https://github.com/semanticpixel/theluistorres">GitHub</a> — MIT.
+        Deployed by GitHub Actions to GitHub Pages. Contribution-graph data syncs nightly
+        via a GraphQL workflow under <code>.github/workflows/sync-contributions.yml</code>.
+      </p>
+
+      <p class="colophon__refrain"><em>I learn every day.</em></p>
+    </Prose>
+  </main>
+</Base>
+
+<style>
+  .colophon {
+    padding: var(--space-8) var(--space-5) var(--space-10);
+  }
+
+  .colophon :global(.prose) :global(.colophon__lede) {
+    font-family: var(--font-display);
+    font-size: var(--type-21);
+    line-height: var(--line-snug);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-text-muted);
+    margin-block-end: var(--space-7);
+  }
+
+  .colophon :global(.prose) :global(.colophon__toc) {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4) var(--space-5);
+    margin-block: var(--space-6);
+  }
+
+  .colophon :global(.prose) :global(.colophon__toc ol) {
+    columns: 2;
+    column-gap: var(--space-5);
+    margin: 0;
+    padding-inline-start: 1.4rem;
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+  }
+
+  .colophon :global(.prose) :global(.colophon__toc li) {
+    margin-block: var(--space-1);
+    break-inside: avoid;
+  }
+
+  .colophon :global(.prose) :global(.colophon__toc a) {
+    color: var(--color-text-muted);
+    text-decoration: none;
+  }
+
+  .colophon :global(.prose) :global(.colophon__toc a:hover) {
+    color: var(--color-action);
+  }
+
+  .colophon :global(.prose) :global(.colophon__refrain) {
+    margin-block-start: var(--space-7);
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    letter-spacing: var(--tracking-wide);
+    text-transform: lowercase;
+  }
+
+  @media (max-width: 640px) {
+    .colophon :global(.prose) :global(.colophon__toc ol) {
+      columns: 1;
+    }
+  }
+</style>

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -1,0 +1,143 @@
+---
+import Base from "~/layouts/Base.astro";
+import { getCollection } from "astro:content";
+
+const entries = (await getCollection("writing")).sort(
+  (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+);
+---
+
+<Base title="Writing — Luis Torres" description="Notes on design engineering — patterns, decisions, the small things.">
+  <main class="writing">
+    <header class="writing__head">
+      <p class="writing__eyebrow">writing</p>
+      <h1 class="writing__title">Notes &amp; gems</h1>
+      <p class="writing__lede">
+        I post most things on <a href="https://ui-gems.com">UI Gems</a> — a notebook of the
+        small interactions worth pointing at. The entries below link out. The home of the writing
+        is over there; this is the index.
+      </p>
+    </header>
+
+    {entries.length === 0 ? (
+      <p class="writing__empty">No entries yet. New posts land here as they ship on UI Gems.</p>
+    ) : (
+      <ul class="writing__list" role="list">
+        {entries.map(entry => (
+          <li>
+            <a class="writing__item" href={entry.data.externalUrl} rel="noopener" target="_blank">
+              <h2 class="writing__item-title">{entry.data.title}</h2>
+              <p class="writing__item-summary">{entry.data.summary}</p>
+              <p class="writing__item-meta">
+                <time datetime={entry.data.date.toISOString().slice(0, 10)}>
+                  {entry.data.date.toISOString().slice(0, 10)}
+                </time>
+                {entry.data.readingTime && <> · {entry.data.readingTime}</>}
+                <span class="writing__item-link" aria-hidden="true"> · read on ui-gems.com →</span>
+              </p>
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </main>
+</Base>
+
+<style>
+  .writing {
+    max-width: var(--container-prose);
+    margin-inline: auto;
+    padding: var(--space-8) var(--space-5) var(--space-10);
+    display: grid;
+    gap: var(--space-7);
+  }
+
+  .writing__head {
+    display: grid;
+    gap: var(--space-3);
+    padding-block-end: var(--space-5);
+    border-block-end: 1px solid var(--color-border);
+  }
+
+  .writing__eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-muted);
+    letter-spacing: var(--tracking-wide);
+    text-transform: lowercase;
+  }
+
+  .writing__title {
+    font-family: var(--font-display);
+    font-size: var(--type-64);
+    line-height: var(--line-tight);
+    letter-spacing: var(--tracking-tight);
+  }
+
+  .writing__lede {
+    color: var(--color-text-muted);
+  }
+
+  .writing__lede a {
+    color: var(--color-action);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.2em;
+  }
+
+  .writing__empty {
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--type-14);
+  }
+
+  .writing__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-5);
+  }
+
+  .writing__item {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-5);
+    text-decoration: none;
+    color: inherit;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    transition: border-color var(--duration-base) var(--ease-out-expo);
+  }
+
+  .writing__item:hover,
+  .writing__item:focus-visible {
+    border-color: var(--color-border-strong);
+  }
+
+  .writing__item-title {
+    font-family: var(--font-display);
+    font-size: var(--type-21);
+    line-height: var(--line-snug);
+    letter-spacing: var(--tracking-tight);
+    color: var(--color-text-default);
+    margin: 0;
+  }
+
+  .writing__item-summary {
+    color: var(--color-text-muted);
+    margin: 0;
+  }
+
+  .writing__item-meta {
+    font-family: var(--font-mono);
+    font-size: var(--type-12);
+    color: var(--color-text-subtle);
+    letter-spacing: var(--tracking-wide);
+    margin: 0;
+  }
+
+  .writing__item-link {
+    color: var(--color-action);
+  }
+</style>


### PR DESCRIPTION
## Summary

Three content pages that carry the voice of the site.

### \`/about\` — the spine

Opens with **"I'm Luis. I write code that pretends not to be there."** Then the LinkedIn semantics-mindset-shift paragraph verbatim from PLAN.md §10 — the load-bearing prose. Plus the six-belief list (including \"I learn every day.\"), a mono timeline, the mentorship paragraph, and the mid-paragraph callout linking to the colophon's AI-tooling section.

### \`/writing\` — the index

Reads the \`writing\` content collection (Zod schema from ST-4). Each entry is a link-out — title, summary, date, reading-time, external URL — sorted desc by date. Two seed entries point at ui-gems.com (root + archive) so the page renders something real now; you can add individual UI Gems posts over time via the schema as you want in-site index entries for specific pieces.

### \`/colophon\` — the architecture decisions log

The senior-bar page. **All 11 sections in prose**, with a two-column TOC at the top:

1. Why this site exists
2. **Stack** — explicit Astro-vs-Next.js opinion paragraph per ST-5 acceptance criteria
3. **Content model** — Zod schemas rendered as a code block, the \"headless-CMS-thinking\" articulation
4. **Design token architecture** — the *thinking in colors → thinking in semantics* thesis, in code
5. **Color modes** — \`prefers-color-scheme\`, \`prefers-contrast: more\`, \`forced-colors: active\`; all three through one token model
6. **Accessibility commitments**
7. **Performance budgets** — current vs. target
8. **Localization model** — sibling collections per locale, fallback ribbon, locale switcher preserves pathname
9. **AI-powered tooling** — *currently a placeholder paragraph*, awaiting your confirmation of which MCPs/skills to list (Open Question from PLAN.md)
10. **What I'd do at production scale** — honest list (CMS, observability, CDN, i18n vendor, design-system release pipeline, a11y gates)
11. **Colophon literal** — fonts, source, license, deploy path

## Acceptance criteria verification

- [x] \`/about\` opens with the exact spine sentence and includes the LinkedIn semantics-mindset-shift paragraph verbatim.
- [x] \`/colophon\` has all 11 sections with substantive prose in each.
- [x] **\`AI tooling\` section** is currently scaffold-only — pending your input. Section 9 contains the prose framing + a clear placeholder explaining what the next commit will replace.
- [x] **Astro-vs-Next.js opinion paragraph** is explicit and defensible — see §2 of the colophon.

## ⚠️ Pending input — AI tooling section

The PLAN.md Open Questions explicitly flagged this: *\"Which existing MCPs / Claude skills to feature on \`/colophon\`? Need repo URLs (or GitHub username scope) to pull README excerpts at build time.\"*

Drop a list of repo URLs (or just confirm \"my GitHub username — pull anything with topic \`mcp\` or \`claude-skill\`\") in a comment here and I'll add the rendered-list follow-up commit. Until then the section ships as a placeholder paragraph that names the pattern without inventing repos.

## Test plan

- [ ] \`pnpm run dev\` — visit \`/about\`, \`/writing\`, \`/colophon\`.
- [ ] Walk every anchor in the colophon TOC — all 11 jumps land cleanly.
- [ ] Toggle dark mode on \`/colophon\` — TOC card, code block, inline code all read correctly.
- [ ] On a 360px viewport, \`/colophon\` TOC collapses to a single column (verify the \`@media\` rule).
- [ ] \`/writing\` shows the two seed entries linking to ui-gems.com.
- [ ] Replace seed UI Gems entries with your actual posts whenever you want — just add new \`.mdx\` files under \`src/content/writing/\` following the schema.

## Conflict notes

- No conflict with #29 (ST-3) — different files.
- This is the last of the parallel children fired this morning; merging it unblocks #18 (ST-6, localization) and downstream.

Closes semanticpixel/theluistorres#17