### PR TITLE
ST-9: cutover — retire legacy build, document Astro as production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # theluistorres
 
-Personal Website — [projectluis.com](https://projectluis.com).
+Personal Website — [projectluis.com](https://projectluis.com). Built with [Astro 5](https://astro.build); deployed to GitHub Pages on every push to `master`. The previous static `index.html` build is archived under [`legacy/`](./legacy) and no longer touches the production output.
+
+## Stack
+
+- **Astro 5** — multi-page, islands, zero-JS by default. Native i18n (`en` default + `/es`), View Transitions, MDX content collections.
+- **Design tokens** in `src/styles/theme/` — primitives → semantic via `light-dark()`, cascade layered `@layer reset, theme, base, components, atoms;`.
+- **CI gate** (`.github/workflows/ci.yml`) — typecheck (`astro check`), build, gzipped bundle budget (home JS &lt; 8 KB, CSS &lt; 12 KB), Lighthouse CI perf/a11y/SEO &ge; 98 on `/`, `/work`, `/work/linkedin-coach`.
+- **Pages deploy** (`.github/workflows/deploy-pages.yml`) — uploads `dist/` as a Pages artifact and publishes via `actions/deploy-pages@v4`. Custom domain is checked in as `public/CNAME`, so the production hostname survives every deploy without manual reconfiguration.
 
 ## Toolchain
 

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,2 +1,15 @@
-# theluistorres
-Personal Website
+# Legacy site — archived
+
+The static `index.html` build that lived at the root of this repo before the
+Astro migration. Kept for archival reference; nothing here is referenced by
+the current production build under `dist/`.
+
+- `index.html` — the previous single-page site
+- `dist/` — pre-build artifacts the old gulp pipeline emitted
+- `gulpfile.js`, `app.js`, `src/`, `scripts/` — original build inputs
+- `CNAME` — the previous `theluistorres.com` mapping (production now uses
+  `projectluis.com`, configured via `public/CNAME` at the repo root)
+
+If you need to bring something forward, copy the file into the new tree
+rather than wiring back any of the legacy build commands — those are no
+longer maintained.


### PR DESCRIPTION
Closes semanticpixel/theluistorres#21

The final issue in the epic. Most of the mechanical work landed earlier (legacy files moved to `legacy/` in ST-0; GitHub Pages workflow added as the hotfix PR #28; `public/CNAME` checked in with `projectluis.com`), so this PR is the documentation pass that formally retires the legacy build and explains the deploy story for anyone landing on the repo cold.

## Changes

**`README.md`** opens with the stack (Astro 5 + cascade-layered token system + CI gate + Pages deploy), states that `legacy/` is the archive, and links to it. The Toolchain section stays where it was.

**`legacy/README.md`** describes what's in the directory and why nothing inside is wired up. The old `theluistorres.com` CNAME is noted as a record of the previous mapping — not served from anywhere.

## Deploy + DNS

- **Deploy target:** GitHub Pages, configured via `.github/workflows/deploy-pages.yml`. Triggers on every push to `master` plus `workflow_dispatch`. Build job runs `pnpm run build` (which itself runs `og` then `astro build`), uploads `dist/` as a Pages artifact; deploy job authenticates via the Pages environment with `id-token: write` + `pages: write` and publishes through `actions/deploy-pages@v4`.
- **Custom domain:** `projectluis.com`. Durable — `public/CNAME` is checked in, so every build emits `dist/CNAME` and GitHub Pages reads it on publish. No manual reconfiguration in repo settings is needed across redeploys, only the one-time toggle to set Source = "GitHub Actions" (already done) and the one-time Custom Domain field entry (also already done).
- **DNS:** no record change in this PR. `projectluis.com` already resolves to GitHub Pages' IPs (`185.199.108-111.153`) from before the migration, so this PR is effectively a content swap behind the same hostname. The legacy `theluistorres.com` mapping stays in `legacy/CNAME` for archival; no apex/subdomain DNS is being touched. TTL considerations: none — A records aren't moving.

## What happens after merge

The Pages deploy workflow fires on `master`. Within ~30 seconds the live `projectluis.com` switches from any previous build to the Astro output. The Footer's `<time datetime>` line reads "last deployed: \<this commit's timestamp\>".

Then the worker for this issue derives `blocked-verify` (because the issue body carries the `## Validation` heading per the parent's plan) and halts the loop until each of the manual checks is confirmed:

- [ ] **First-impression check** — peer engineer opens cold, reads all three takeaways within 5 min.
- [ ] **Hard budgets in CI** — already enforced on PRs by `ci.yml`; production Lighthouse trace should match.
- [ ] **Mode coverage** — manual matrix on `/colophon`: `prefers-color-scheme` (light + dark), `prefers-contrast: more`, `forced-colors: active`, `prefers-reduced-motion: reduce`.
- [ ] **i18n smoke** — `/es` resolves on every route; locale switcher preserves pathname; untranslated pages show the fallback ribbon.
- [ ] **Pipeline smoke** — `sync-contributions.yml` runs nightly; build doesn't break on missing token.

## Acceptance criteria

- [x] `projectluis.com` serves the Astro build (after merge → Pages deploy fires); legacy reachable under `/legacy/` in source only — it's not deployed as a route.
- [x] CI gate enforces Lighthouse perf/a11y/SEO ≥ 98 on the 3 sampled routes (ST-8).
- [x] Footer "last deployed" reads build time via build-time `<time datetime>` (ST-2).
- [x] DNS state documented above; no change in this PR.

## Test plan

- [ ] Merge fires the deploy workflow; both `Build Astro` and `Deploy` jobs succeed.
- [ ] `curl -I https://projectluis.com` returns 200 + the right `last-modified`.
- [ ] Click through `/`, `/work`, `/work/linkedin-coach`, `/about`, `/colophon`, `/writing`, `/sandbox`, `/404`, `/es/*`.
- [ ] Footer timestamp matches the deploy commit within a few minutes.