### PR TITLE
hero: name-aligned horizon + tagline + theme persistence across VT

### DIFF
--- a/src/components/Contributions.astro
+++ b/src/components/Contributions.astro
@@ -91,7 +91,7 @@ const ariaLabel = snapshot
 <svg
   class="contributions"
   viewBox={`0 0 ${W} ${H}`}
-  preserveAspectRatio="xMaxYMax meet"
+  preserveAspectRatio="xMidYMid meet"
   role="img"
   aria-label={ariaLabel}
   data-contributions
@@ -101,7 +101,12 @@ const ariaLabel = snapshot
   data-last-updated={lastUpdated}
 >
   <defs>
-    <radialGradient id="contributions-mask" cx="100%" cy="100%" r="120%">
+    {/* Reveal a right-center band so the cells read as a horizon line
+        aligned with the hero name's eyeline — type and texture as one
+        composition, not type with a corner decoration. The previous
+        bottom-right anchor pushed the visible grid below the type lockup
+        and orphaned it visually. */}
+    <radialGradient id="contributions-mask" cx="100%" cy="50%" r="120%">
       <stop offset="0%"  stop-color="white" stop-opacity="1" />
       <stop offset="60%" stop-color="white" stop-opacity="0.6" />
       <stop offset="100%" stop-color="white" stop-opacity="0" />

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,7 +22,7 @@
   "work.fallbackRibbon": "This page hasn't been translated yet — showing the English version.",
   "work.allStudies": "all case studies",
   "work.backLink": "← all case studies",
-  "hero.pitch": "design engineer building for the web",
+  "hero.pitch": "making things invisible",
   "hero.bio": "Currently @ Superhuman. Previously LinkedIn, Amazon.",
   "hero.statPending": "graph syncing soon · interactive grid mounts on scroll",
   "hero.statTemplate": "{total} contributions · {streak} streak · synced {synced}",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -22,7 +22,7 @@
   "work.fallbackRibbon": "Esta página aún no está traducida — mostrando la versión en inglés.",
   "work.allStudies": "todos los casos de estudio",
   "work.backLink": "← todos los casos de estudio",
-  "hero.pitch": "ingeniero de diseño construyendo para la web",
+  "hero.pitch": "haciendo las cosas invisibles",
   "hero.bio": "Actualmente en Superhuman. Antes: LinkedIn, Amazon.",
   "hero.statPending": "el grafo se sincroniza pronto · la cuadrícula interactiva carga al hacer scroll",
   "hero.statTemplate": "{total} contribuciones · {streak} días seguidos · sincronizado {synced}",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -44,16 +44,28 @@ const canonical = new URL(Astro.url.pathname, Astro.site).toString();
        * Pre-paint theme resolution: read localStorage, set data-theme on <html>
        * before first paint to prevent a flash of incorrect theme. Falls back to
        * system preference when nothing is stored.
+       *
+       * ClientRouter swaps the document on every navigation, so the stored
+       * preference also has to be re-applied to `e.newDocument` *before* the
+       * swap commits — otherwise the new page paints with whatever theme its
+       * server-rendered HTML had (i.e. none → falls back to system pref),
+       * flickering away from the user's choice.
        */
       (function () {
-        try {
-          const stored = localStorage.getItem("theme");
-          if (stored === "light" || stored === "dark") {
-            document.documentElement.dataset.theme = stored;
+        function apply(doc) {
+          try {
+            var stored = localStorage.getItem("theme");
+            if (stored === "light" || stored === "dark") {
+              doc.documentElement.dataset.theme = stored;
+            }
+          } catch (_) {
+            /* private mode, etc — leave system preference in charge */
           }
-        } catch (_) {
-          /* private mode, etc — leave system preference in charge */
         }
+        apply(document);
+        document.addEventListener("astro:before-swap", function (e) {
+          apply(e.newDocument);
+        });
       })();
     </script>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ try {
 
       <div class="hero__type">
         <HeroName name="Luis Torres" />
-        <p class="hero__pitch">design engineer building for the web</p>
+        <p class="hero__pitch">making things invisible</p>
         <p class="hero__bio">Currently @ Superhuman. Previously LinkedIn, Amazon.</p>
         <p class="hero__stat">
           <span class="hero__stat-rule" aria-hidden="true">────</span>


### PR DESCRIPTION
Three small changes, all landing on the hero. Wrapped together because they read as one design intent.

## 1. Theme persistence across view transitions (bug fix)

`Base.astro`'s pre-paint script set `data-theme` on `<html>` once at first load. `ClientRouter` swaps the document on every navigation, so the attribute got dropped each hop — meaning a user who toggled to dark and clicked **any** nav link flickered back to system preference until the next reload. Easy to reproduce on the live site right now: open `projectluis.com`, click the toggle to dark, click Work in the nav → you'll see the flash back to light/auto.

Fix is one `astro:before-swap` listener that re-applies the stored preference to `e.newDocument.documentElement.dataset.theme` before the swap commits. Inline script stays inline; no extra runtime cost.

**Verified:**
```
localStorage.theme = 'dark' → reload → data-theme="dark" ✓
                            → nav to /work → data-theme="dark" ✓
```

## 2. Hero composition — name-aligned horizon

`Contributions.astro` was rendering with `preserveAspectRatio="xMaxYMax meet"` (bottom-right anchor) and an SVG-internal radial mask centered at `cx="100%" cy="100%"`. The grid lived as a corner block under the type — reading as "type and decoration in separate rooms" rather than one composition.

Shifted to `xMidYMid meet` + `cy="50%"`. The grid now threads the horizon line *through* the name's eyeline, bleeding off the right edge as a feathered band. Type + texture as one composition.

No DOM changes, no new tokens, same opacity, same data.

### Before (master)
Grid anchored to the bottom-right corner of the hero, sitting under the type lockup.

### After (this PR)
Grid centered with the name vertically, extending right with a feathered fade-out — reads as a horizon line behind the type.

## 3. Tagline

`"design engineer building for the web"` → `"making things invisible"`

Luis's literal LinkedIn headline. Stronger voice than the resume-y "engineer building for X" phrasing. Updated in both `i18n/en.json` (`"making things invisible"`) and `i18n/es.json` (`"haciendo las cosas invisibles"`), plus the hardcoded EN string on the home page (which should probably also pull from i18n at some point — out of scope here).

## Diff scope

5 files, +28 / -11:
- `src/layouts/Base.astro` — 24 lines (theme bootstrap rewrite)
- `src/components/Contributions.astro` — 9 lines (2 attribute changes + 1 comment explaining the move)
- `src/pages/index.astro` — 2 lines (tagline string)
- `src/i18n/en.json` — 2 lines
- `src/i18n/es.json` — 2 lines

## CI / budgets

- `pnpm typecheck` — 36 files, 0 issues ✓
- `pnpm build` — 25 pages, 2.5s ✓
- `scripts/bundle-size.mjs` — CSS 5.69KB / 12KB budget, JS 7.27KB / 8KB budget ✓
- Lighthouse should be unaffected (no new JS, same DOM)

## Context

I'm a contributor to the design plan that PLAN.md was generated from — this PR is the first slice of comparing notes between the ABC-shipped build and an alternate implementation I had in parallel. Findings I'd surface for a separate PR:

- **a11y CI step** — adding `@axe-core/playwright` to the CI workflow would catch a handful of contrast + landmark violations that exist on master right now (`--color-text-faint` at 3.13:1, missing `<main>` on `/theme` and `/404`, `<h3>` after `<h1>` on Work cards, FallbackRibbon outside any landmark, `opacity: 0.92` on draft cards alpha-blending text). Happy to follow up.
- **Substantive draft prose** in case studies — master's "Pending Luis's review" disclaimers paired with real intro paragraphs read better than the bracketed scaffolds in the alternate branch. Keeping master's approach.
- **Localization** is a bigger PR if/when Luis wants the `/es` paths to add a Spanish-translated content layer beyond chrome.

Happy to split or drop any of the three; the theme-persistence one is the only strict bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_