### PR TITLE
a11y: axe-core CI job + fixes for 3 baseline violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,46 @@ jobs:
 
       - name: Lighthouse CI
         run: npx --yes @lhci/cli@0.14 autorun --config=./lighthouserc.json
+
+  a11y:
+    # Complements Lighthouse's a11y score (a single aggregate threshold) with
+    # an enumeration-style audit — axe-core walks every route in light and
+    # dark color schemes and reports every offending node by selector.
+    # Catches contrast / heading-order / landmark issues that wouldn't budge
+    # the Lighthouse aggregate enough to fail the existing job.
+    name: a11y (axe-core, every route × light/dark)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run axe-core audit
+        run: pnpm run audit:a11y
+
+      - name: Upload a11y evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-evidence
+          path: tmp/a11y/
+          retention-days: 14
+          if-no-files-found: warn

--- a/package.json
+++ b/package.json
@@ -18,18 +18,22 @@
     "preview": "astro preview",
     "astro": "astro",
     "og": "node scripts/og-image.mjs",
-    "typecheck": "astro check"
+    "typecheck": "astro check",
+    "audit:a11y": "node scripts/audit-a11y.mjs"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/mdx": "^4.3.14",
     "@astrojs/sitemap": "^3.7.2",
+    "@axe-core/playwright": "^4.11.3",
     "@fontsource-variable/fraunces": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource/fraunces": "^5.2.9",
     "@resvg/resvg-js": "^2.6.2",
     "astro": "^5.18.1",
+    "axe-core": "^4.11.4",
+    "playwright": "^1.60.0",
     "satori": "^0.26.0",
     "satori-html": "^0.3.2",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
       '@fontsource-variable/fraunces':
         specifier: ^5.2.9
         version: 5.2.9
@@ -35,6 +38,12 @@ importers:
       astro:
         specifier: ^5.18.1
         version: 5.18.1(@types/node@24.12.4)(rollup@4.60.4)(typescript@5.9.3)(yaml@2.9.0)
+      axe-core:
+        specifier: ^4.11.4
+        version: 4.11.4
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       satori:
         specifier: ^0.26.0
         version: 0.26.0
@@ -96,6 +105,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.4':
     resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -982,6 +996,10 @@ packages:
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1293,6 +1311,11 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1704,6 +1727,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -2415,6 +2448,11 @@ snapshots:
   '@astrojs/yaml2ts@0.2.4':
     dependencies:
       yaml: 2.9.0
+
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -3168,6 +3206,8 @@ snapshots:
       - uploadthing
       - yaml
 
+  axe-core@4.11.4: {}
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -3491,6 +3531,9 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4246,6 +4289,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 

--- a/scripts/audit-a11y.mjs
+++ b/scripts/audit-a11y.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/*
+ * A11y audit runner — boots `astro preview` against the built dist/, walks
+ * every public route with Playwright + axe-core (light AND dark color
+ * schemes), and exits non-zero on any WCAG-tagged violation.
+ *
+ * Why this exists alongside Lighthouse CI: Lighthouse's a11y category bundles
+ * many checks under a single 0.98 floor and is partial about color-contrast
+ * (it samples). axe-core enumerates every offending node — useful for
+ * catching specific regressions (e.g. a low-contrast token on one card type)
+ * that wouldn't drop the aggregate score under the Lighthouse threshold.
+ *
+ * Runs locally with:  pnpm run build && pnpm run audit:a11y
+ * Runs in CI:         ./.github/workflows/ci.yml — a11y job, after build.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import { setTimeout as wait } from "node:timers/promises";
+import { chromium } from "playwright";
+import { AxeBuilder } from "@axe-core/playwright";
+
+const PORT = 4322;
+const BASE = `http://localhost:${PORT}`;
+const OUT = "tmp/a11y";
+
+/* Every public surface. Add new routes here as they ship. */
+const ROUTES = [
+  "/",
+  "/about",
+  "/work",
+  "/work/linkedin-coach",
+  "/work/linkedin-dark-mode",
+  "/work/linkedin-design-system",
+  "/work/grammarly-ai-detector",
+  "/work/superhuman-com",
+  "/writing",
+  "/colophon",
+  "/sandbox",
+  "/sandbox/token-scale",
+  "/sandbox/motion-lab",
+  "/theme",
+  "/404",
+  "/es",
+  "/es/about",
+  "/es/work",
+  "/es/work/linkedin-coach",
+  "/es/work/superhuman-com",
+  "/es/colophon",
+];
+
+async function startPreview() {
+  const proc = spawn("pnpm", ["exec", "astro", "preview", "--port", String(PORT)], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  for (let i = 0; i < 30; i++) {
+    try {
+      const r = await fetch(`${BASE}/`);
+      if (r.ok) return proc;
+    } catch { /* not up yet */ }
+    await wait(500);
+  }
+  proc.kill();
+  throw new Error(`Preview server never became ready on ${BASE}`);
+}
+
+async function main() {
+  await mkdir(OUT, { recursive: true });
+
+  console.log("Booting preview server…");
+  const server = await startPreview();
+  console.log(`Server up at ${BASE}\n`);
+
+  const browser = await chromium.launch({ headless: true, args: ["--no-sandbox"] });
+  const summary = { light: {}, dark: {} };
+  let total = 0;
+
+  try {
+    for (const colorScheme of /** @type {const} */ (["light", "dark"])) {
+      const ctx = await browser.newContext({
+        viewport: { width: 1440, height: 900 },
+        colorScheme,
+      });
+      const page = await ctx.newPage();
+
+      for (const route of ROUTES) {
+        await page.goto(`${BASE}${route}`, { waitUntil: "networkidle" });
+        const results = await new AxeBuilder({ page })
+          .withTags(["wcag2a", "wcag2aa", "wcag21aa", "wcag22aa"])
+          .analyze();
+        total += results.violations.length;
+        summary[colorScheme][route] = results.violations.map((v) => ({
+          id: v.id,
+          impact: v.impact,
+          nodes: v.nodes.length,
+          help: v.help,
+          targets: v.nodes.slice(0, 3).map((n) => n.target.join(" / ")),
+        }));
+      }
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+    server.kill("SIGTERM");
+  }
+
+  await writeFile(`${OUT}/axe-summary.json`, JSON.stringify(summary, null, 2));
+
+  console.log("=== AXE A11Y AUDIT ===");
+  for (const scheme of Object.keys(summary)) {
+    console.log(`\n[${scheme} mode]`);
+    for (const route of ROUTES) {
+      const v = summary[scheme][route] ?? [];
+      if (v.length === 0) {
+        console.log(`  ✅ ${route}`);
+      } else {
+        console.log(`  ❌ ${route} — ${v.length} violation${v.length === 1 ? "" : "s"}`);
+        for (const item of v) {
+          console.log(`        · [${item.impact}] ${item.id} (${item.nodes}× — ${item.help})`);
+          if (item.targets[0]) console.log(`            → ${item.targets[0]}`);
+        }
+      }
+    }
+  }
+  console.log(`\nTotal violations: ${total}`);
+
+  if (total > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/pages/sandbox/token-scale.astro
+++ b/src/pages/sandbox/token-scale.astro
@@ -3,6 +3,38 @@ import Base from "~/layouts/Base.astro";
 
 const scales = ["bone", "slate", "terracotta", "moss", "amber"] as const;
 const steps = [0, 20, 40, 60, 80, 100] as const;
+
+/*
+ * Primitive hex values, mirrored from src/styles/theme/primitives.css so the
+ * label can pick a per-cell contrast-safe text color server-side. Kept in
+ * sync by hand — if primitives.css changes, update this table.
+ *
+ * The previous approach (`light-dark(rgba(0 0 0 / 0.55), rgba(255 255 255 / 0.7))`
+ * + `mix-blend-mode: difference`) read like a clean trick but couldn't be
+ * statically reasoned about by axe-core, and on mid-luminance cells like
+ * terracotta-60 it landed below the AA floor for small text.
+ */
+const HEX: Record<string, Record<number, string>> = {
+  bone:       { 0: "#fafaf7", 20: "#f4f2ec", 40: "#e8e4da", 60: "#d4cfc2", 80: "#9e9a8e", 100: "#4a4842" },
+  slate:      { 0: "#f5f7fa", 20: "#e2e6eb", 40: "#b4bdc6", 60: "#6f7984", 80: "#3d444b", 100: "#1a1d20" },
+  terracotta: { 0: "#fdf1ee", 20: "#f2c8c0", 40: "#dc8e84", 60: "#c2625e", 80: "#8e423f", 100: "#5a2724" },
+  moss:       { 0: "#eef3eb", 20: "#c9d5bd", 40: "#8fa37c", 60: "#5e7549", 80: "#3e4f2e", 100: "#232e1a" },
+  amber:      { 0: "#fbf1de", 20: "#f0d894", 40: "#ddb257", 60: "#b68628", 80: "#7a5916", 100: "#3e2c0a" },
+};
+
+function relLum(hex: string): number {
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const f = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+
+/* Threshold 0.18 — every mid-luminance step (bone-60, terracotta-60,
+   moss-60, amber-60) clears AA against the chosen ink. Verified by hand. */
+function inkFor(hex: string): string {
+  return relLum(hex) > 0.18 ? "#000" : "#fff";
+}
 ---
 
 <Base title="Token-scale visualizer — Sandbox" description="A perceptual readout of the five primitive color scales." transitions={false}>
@@ -23,17 +55,21 @@ const steps = [0, 20, 40, 60, 80, 100] as const;
         <div class="ramp">
           <h2 class="ramp__name">{family}</h2>
           <ol class="ramp__row" role="list">
-            {steps.map((step, i) => (
-              <li
-                class="ramp__cell"
-                style={`
-                  background: var(--${family}-${step});
-                  --lightness: ${100 - i * 16}%;
-                `}
-              >
-                <span class="ramp__label">{family}-{step}</span>
-              </li>
-            ))}
+            {steps.map((step, i) => {
+              const hex = HEX[family][step];
+              return (
+                <li
+                  class="ramp__cell"
+                  style={`
+                    background: var(--${family}-${step});
+                    --lightness: ${100 - i * 16}%;
+                    --ink: ${inkFor(hex)};
+                  `}
+                >
+                  <span class="ramp__label">{family}-{step}</span>
+                </li>
+              );
+            })}
           </ol>
         </div>
       ))}
@@ -130,10 +166,11 @@ const steps = [0, 20, 40, 60, 80, 100] as const;
 
   .ramp__label {
     font-family: var(--font-mono);
-    font-size: 10px;
+    font-size: 11px;
     letter-spacing: var(--tracking-wide);
-    color: light-dark(rgba(0, 0, 0, 0.55), rgba(255, 255, 255, 0.7));
-    mix-blend-mode: difference;
+    /* Per-cell ink picked server-side via inkFor(hex) for AA contrast on
+       every swatch — see the inline style on each .ramp__cell. */
+    color: var(--ink, currentColor);
   }
 
   .lab__notes {

--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -138,6 +138,12 @@ const entries = (await getCollection("writing")).sort(
   }
 
   .writing__item-link {
-    color: var(--color-action);
+    /* `--color-action` (terracotta-40 in dark mode) on the elevated card
+       surface (slate-80) hits 3.82:1 — below the WCAG AA floor for normal
+       text. Card chrome reads fine when it inherits the default text color;
+       the parent <a> already carries the link semantics, so we keep that
+       contrast without losing the "this points off-site" hint. */
+    color: var(--color-text-default);
+    font-weight: 500;
   }
 </style>


### PR DESCRIPTION
## What

Adds an axe-core CI job alongside Lighthouse, plus the two contrast fixes the baseline run found on master.

## Baseline

Ran `axe-core` against the current `master` build, walking 21 routes × 2 color schemes. 3 violations:

| Route | Mode | Rule | Nodes | Selector |
|---|---|---|---|---|
| `/sandbox/token-scale` | light | `color-contrast` | 23 | `.ramp__label` |
| `/sandbox/token-scale` | dark | `color-contrast` | 23 | `.ramp__label` |
| `/writing` | dark | `color-contrast` | 2 | `.writing__item-link[aria-hidden="true"]` |

Master is genuinely clean — these are the only WCAG-tagged hits. The ABC-shipped pages handle landmarks, heading order, and ARIA correctly.

## Fixes

### 1. `/sandbox/token-scale` ramp labels

The label used `light-dark(rgba(0 0 0 / 0.55), rgba(255 255 255 / 0.7))` + `mix-blend-mode: difference`. Clean trick, but:
- axe can't statically reason about blend-mode contrast (the effective ink depends on what's under it)
- The alpha was below AA on mid-luminance swatches (bone-60, terracotta-60, moss-60, amber-60), all in the 3.0–3.8:1 range

Fix: compute a per-cell solid ink (`#000` or `#fff`) server-side from each cell's hex via a 0.18 relative-luminance threshold. Verified by hand that every step on every primitive ramp clears 4.5:1 with the chosen ink.

Primitives table is mirrored inside `token-scale.astro` from `primitives.css` — comment notes the sync expectation. The whole point of the sandbox page is to visualize those values, so inlining feels appropriate.

### 2. `/writing` "read on ui-gems.com" indicator

`--color-action` resolves to `terracotta-40` in dark mode. On the elevated card surface (`--color-surface` = `slate-80`), that's 3.82:1 — below AA's 4.5:1 floor for normal text. The same token passes on the page bg (slate-100) where it's used elsewhere, so this is specifically the elevated-surface case.

The element is `aria-hidden="true"` (the parent `<a>` carries the link semantics), but axe correctly flags low-contrast text even when it's hidden from AT — sighted users with low vision still need to read it.

Fix: drop the terracotta override, inherit `--color-text-default` + `font-weight: 500`. Reads as emphasized chrome instead of competing with the link target.

## CI

New `a11y` job in `ci.yml`, runs after `build` and consumes the dist artifact:

```yaml
- pnpm exec playwright install --with-deps chromium
- pnpm run audit:a11y
```

`scripts/audit-a11y.mjs` boots `astro preview` against the built `dist/`, walks every route under light + dark, and exits 1 on any violation. Evidence goes to `tmp/a11y/axe-summary.json` and is uploaded as an artifact on red runs.

Complements Lighthouse rather than replacing it — Lighthouse bundles a11y under a single 0.98 aggregate threshold; axe enumerates per-node so specific regressions surface with selectors. A two-node contrast issue won't drop the Lighthouse score under 0.98, but it'll fail this job.

## Locally

```
pnpm run build
pnpm run audit:a11y
# Total violations: 0
```

## Diff scope

```
.github/workflows/ci.yml             | 47 +++++++++++++++++++++++++++++++++++++
package.json                         |  6 ++++-
pnpm-lock.yaml                       | (lockfile)
scripts/audit-a11y.mjs               | NEW (~120 LOC)
src/pages/sandbox/token-scale.astro  | 38 ++++++++++++++++++++++++------
src/pages/writing/index.astro        |  9 +++++++-
```

## Heads-up on CI

This branch will likely show red on the `build` job until #36 (the pnpm-version-pin removal) lands or this branch is rebased — see `Error: Multiple versions of pnpm specified` in the install step. The `a11y` job itself is fine; it just can't run until `build` produces the artifact. Happy to rebase once #36 is in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_