### PR TITLE
hero: tune name + pitch typography, add font-size token scale

### DIFF
--- a/src/components/HeroName.astro
+++ b/src/components/HeroName.astro
@@ -66,7 +66,7 @@ const { name } = Astro.props;
     isolation: isolate;
     margin: 0;
     font-family: var(--font-display);
-    font-size: var(--type-96);
+    font-size: var(--type-64);
     font-weight: 300;
     line-height: var(--line-tight);
     letter-spacing: var(--tracking-tight);
@@ -88,11 +88,11 @@ const { name } = Astro.props;
      onto the bone surface gives the small chromatic fringe; in dark mode
      screening the inverted scale reproduces the same fringe direction. */
   .hero-name > *:nth-child(1) { color: light-dark(var(--terracotta-60), var(--terracotta-40)); }
-  .hero-name > *:nth-child(2) { color: light-dark(var(--slate-80),      var(--slate-40)); }
-  .hero-name > *:nth-child(3) { color: light-dark(var(--bone-80),       var(--bone-40)); }
+  .hero-name > *:nth-child(2) { color: light-dark(var(--bone-80),       var(--bone-40)); }
+  .hero-name > *:nth-child(3) { color: light-dark(var(--slate-80),      var(--slate-40)); }
 
   .hero-name > * {
-    mix-blend-mode: light-dark(multiply, screen);
+    mix-blend-mode: multiply;
   }
 
   /* Ambient pulse — set by the JS scheduler. */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,12 @@
 ---
-import Base from "~/layouts/Base.astro";
-import HeroName from "~/components/HeroName.astro";
-import WorkCard from "~/components/WorkCard.astro";
-import Contributions from "~/components/Contributions.astro";
-import ContributionsInteractive from "~/components/ContributionsInteractive.astro";
 import { getCollection } from "astro:content";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import Contributions from "~/components/Contributions.astro";
+import ContributionsInteractive from "~/components/ContributionsInteractive.astro";
+import HeroName from "~/components/HeroName.astro";
+import WorkCard from "~/components/WorkCard.astro";
+import Base from "~/layouts/Base.astro";
 
 /*
  * Featured work — limited to 3 entries marked `featured: true` in the
@@ -120,10 +120,11 @@ try {
   }
 
   .hero__pitch {
-    font-family: var(--font-body);
+    font-family: var(--font-display);
+    font-style: italic;
     font-size: var(--type-21);
     line-height: var(--line-snug);
-    color: var(--color-text-muted);
+    color: var(--color-text-default);
     max-width: 30ch;
   }
 

--- a/src/styles/theme/typography.css
+++ b/src/styles/theme/typography.css
@@ -21,6 +21,16 @@
   --type-64: clamp(4rem,      3.06rem + 4.68vw, 6.06rem);
   --type-96: clamp(6rem,      4.4rem + 8vw,     9.5rem);
 
+  --font-size-xs: clamp(0.75rem, 0.71rem + 0.20vw, 0.875rem);
+  --font-size-sm: clamp(0.875rem, 0.82rem + 0.27vw, 1rem);
+  --font-size-base: clamp(1rem, 0.93rem + 0.36vw, 1.125rem);
+  --font-size-md: clamp(1.125rem, 1.04rem + 0.43vw, 1.25rem);
+  --font-size-lg: clamp(1.375rem, 1.24rem + 0.66vw, 1.625rem);
+  --font-size-xl: clamp(1.75rem, 1.51rem + 1.20vw, 2.25rem);
+  --font-size-2xl: clamp(2.25rem, 1.79rem + 2.32vw, 3.5rem);
+  --font-size-3xl: clamp(3rem, 2.10rem + 4.55vw, 5.5rem);
+  --font-size-4xl: clamp(4rem, 2.50rem + 7.50vw, 8rem);
+
   --line-tight:   1.1;
   --line-snug:    1.25;
   --line-default: 1.5;


### PR DESCRIPTION
## Summary
Hero polish on the homepage — smaller name, italic Fraunces pitch line, cleaner blend math on the chromatic-split stack — plus a parallel `--font-size-*` fluid token scale landed ahead of broader adoption.

## Changes
- **Hero name** (`HeroName.astro`): font size `--type-96` → `--type-64`; chromatic-split layers reordered so bone sits between terracotta and slate; `mix-blend-mode` simplified to `multiply` (was `light-dark(multiply, screen)`).
- **Hero pitch** (`index.astro`): italic Fraunces at default text color, was body sans at muted — reads as tagline, not caption. Also alphabetized the import block.
- **Typography tokens** (`typography.css`): adds `--font-size-xs` through `--font-size-4xl` fluid clamps alongside the existing `--type-*` scale. Currently unused; lands the scale so future component PRs don't need to bundle token additions.

## Test plan
- [ ] `pnpm typecheck` clean (verified locally)
- [ ] Visit `/` in light and dark mode — hero name reads with the new chromatic fringe in both
- [ ] Hover the hero name — split animates ~0.35rem and snaps back on mouse-out
- [ ] Confirm pitch line renders italic Fraunces at default text color, not muted body sans
- [ ] With `prefers-reduced-motion: reduce`, hero name collapses to single static layer