### PR TITLE
contrib: drop wrap scroll, let grid SVG overflow visible

### DIFF
--- a/src/components/ContributionsInteractive.astro
+++ b/src/components/ContributionsInteractive.astro
@@ -234,13 +234,13 @@ const H = 7 * STRIDE;
 
   .contrib__grid-wrap {
     position: relative;
-    overflow-x: auto;
   }
 
   .contrib__grid {
     display: block;
     inline-size: 100%;
     min-inline-size: 720px;
+    overflow: visible;
   }
 
   /* Same terracotta scale as the hero background, full opacity here. */


### PR DESCRIPTION
## Summary
The contribution grid's hover drop-shadow and today-cell pulse glow were being clipped at the SVG bounds. Removing `overflow-x: auto` on `.contrib__grid-wrap` and setting the SVG to `overflow: visible` restores both effects and lets the page handle narrow-viewport horizontal flow instead of nesting a scrollbar inside the section.

## Changes
- `.contrib__grid-wrap`: drop `overflow-x: auto`
- `.contrib__grid` (SVG): add `overflow: visible`

## Test plan
- [ ] Hover a cell in the interactive grid — terracotta drop-shadow renders fully, not clipped at the SVG edge
- [ ] Watch the today-cell pulse — glow extends past the cell, not cropped
- [ ] Resize to <720px — confirm the grid overflows the page rather than scrolling inside its own container (intentional behavior change)
- [ ] `pnpm typecheck` clean (verified locally)