### PR TITLE
hero: soften the contributions feather to match the Phase 0 prototype

### DIFF
--- a/src/components/Contributions.astro
+++ b/src/components/Contributions.astro
@@ -100,38 +100,28 @@ const ariaLabel = snapshot
   data-today-count={todayCount}
   data-last-updated={lastUpdated}
 >
-  <defs>
-    {/* Reveal a right-center band so the cells read as a horizon line
-        aligned with the hero name's eyeline — type and texture as one
-        composition, not type with a corner decoration. The previous
-        bottom-right anchor pushed the visible grid below the type lockup
-        and orphaned it visually. */}
-    <radialGradient id="contributions-mask" cx="100%" cy="50%" r="120%">
-      <stop offset="0%"  stop-color="white" stop-opacity="1" />
-      <stop offset="60%" stop-color="white" stop-opacity="0.6" />
-      <stop offset="100%" stop-color="white" stop-opacity="0" />
-    </radialGradient>
-    <mask id="contributions-fade">
-      <rect width={W} height={H} fill="url(#contributions-mask)" />
-    </mask>
-  </defs>
+  {/* No SVG-internal mask anymore — consumers control feathering via a CSS
+      `mask-image` on the wrapping element. SVG `radialGradient` is locked to
+      circles (relative to the bounding-box diagonal), so the previous mask
+      could only fade radially from a corner. The hero needs an asymmetric
+      ellipse (wider than tall) feathered around the name's eyeline, which
+      CSS `mask-image: radial-gradient(ellipse W% H% at X% Y%, ...)` expresses
+      directly. Each consumer (hero, /es hero) applies its own mask. */}
 
-  <g mask="url(#contributions-fade)">
-    {weeks.map((week, wi) => (
-      week.map((day, di) => day && (
-        <rect
-          x={wi * STRIDE}
-          y={di * STRIDE}
-          width={CELL}
-          height={CELL}
-          rx={2}
-          ry={2}
-          data-date={day.date}
-          data-level={day.level}
-        />
-      ))
-    ))}
-  </g>
+  {weeks.map((week, wi) => (
+    week.map((day, di) => day && (
+      <rect
+        x={wi * STRIDE}
+        y={di * STRIDE}
+        width={CELL}
+        height={CELL}
+        rx={2}
+        ry={2}
+        data-date={day.date}
+        data-level={day.level}
+      />
+    ))
+  ))}
 </svg>
 
 <style>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -95,14 +95,14 @@ try {
   }
 
   .hero__graph {
+    /* See src/pages/index.astro for the rationale on the ellipse mask. */
     position: absolute;
     inset: 0;
     pointer-events: none;
     z-index: -1;
-    display: flex;
-    align-items: end;
-    justify-content: end;
     overflow: hidden;
+    -webkit-mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
+            mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
   }
 
   .hero__type {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -102,15 +102,19 @@ try {
   }
 
   .hero__graph {
-    /* Anchored bottom-right, full hero bounds, behind the type layer. */
+    /* Name-aligned horizon: the grid fills the full hero bounds, then a
+       CSS ellipse mask reveals a wide horizontal band centered on the
+       name's eyeline. Asymmetric (70% × 60%) so the falloff is gentler
+       horizontally than vertically — type + texture as one composition.
+       The 35%/80% stops give a true opaque plateau + long soft fade
+       (matches the original Phase-0 prototype). */
     position: absolute;
     inset: 0;
     pointer-events: none;
     z-index: -1;
-    display: flex;
-    align-items: end;
-    justify-content: end;
     overflow: hidden;
+    -webkit-mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
+            mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
   }
 
   .hero__type {


### PR DESCRIPTION
## What

Tunes the hero contribution-grid mask to match the Phase 0 prototype's soft, wide feather. Pulls the mask out of the SVG (where it was forced to be a corner-anchored circle) and onto the `.hero__graph` parent as a CSS `radial-gradient(ellipse …)`.

## Before / after

Master currently fades the grid via an SVG-internal `<radialGradient>` with `cx="100%" cy="50%" r="120%"` — a circle anchored to the right edge. With real data the cells cluster on the right ~50% and a hard perceptual boundary shows on the left, which reads as "type with a corner decoration."

The Phase 0 prototype used a CSS ellipse instead:

```css
mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
```

— wider than tall, centered inside the SVG at 80% 50%, with a true opaque plateau (0 → 35% of radius) before a long fade out to 80%. That gives the horizontal band of cells with a soft top/bottom and a long left-side falloff you'd flagged as the right composition.

## Why this PR moves the mask out of the SVG

SVG `<radialGradient>` only describes a circle (relative to the bounding-box diagonal); there's no `ry` analog. CSS `mask-image` supports `ellipse W% H%` directly. Pulling the mask up to the wrapping element is the right place for it anyway — `Contributions.astro` now renders the raw grid and consumers control the feather. Single responsibility, lighter component.

## Diff scope

3 files, +32 / −38:

- `src/components/Contributions.astro` — drop the SVG `<defs>`/`<mask>` wrapper; the rects render directly. Comment explains the contract.
- `src/pages/index.astro` — apply the ellipse mask to `.hero__graph` (with `-webkit-` prefix for Safari).
- `src/pages/es/index.astro` — same, comment cross-refs the EN file.

## Budgets

- `pnpm run build` — clean, 25 pages, 2.6s
- `pnpm typecheck` — 37 files, 0 issues
- Home gzip: CSS 5.73 KB (was 5.69 KB; +0.04 KB inline mask declaration), JS unchanged at 7.27 KB. Both well under budget.

## A11y

No regression — the mask is decorative. `Contributions.astro` retains its existing `role="img"` and dynamic `aria-label` reporting total + streak.

## Local preview caveat

The screenshots I generated locally don't show the effect dramatically because `public/data/contributions.json` is absent in the container build, so every cell falls back to level-0 (`--color-surface`) and is barely visible against the page background. With your live data, the band of varying cell levels shows the mask shape clearly — same way as the Phase 0 prototype.

## Context

Follow-up to #35 — the hero composition shift landed, but the soft-feather quality of the prototype hadn't carried over. This is the smaller follow-up that closes that gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_