### PR TITLE
hero: stack graph + type with grid so the mask hits the actual cell band

### DIFF
--- a/src/components/Contributions.astro
+++ b/src/components/Contributions.astro
@@ -127,7 +127,13 @@ const ariaLabel = snapshot
 <style>
   .contributions {
     inline-size: 100%;
-    block-size: 100%;
+    /* Height derives from the viewBox aspect ratio. The previous
+       `block-size: 100%` forced the SVG to fill its container, which
+       left the actual cell band as a small central strip surrounded by
+       empty whitespace — masks applied at the container level then
+       mostly missed the cells. Letting the SVG be content-height makes
+       the container hug the cells, so any mask hits the band directly. */
+    block-size: auto;
     opacity: 0.18;
     pointer-events: none;
   }

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -86,20 +86,23 @@ try {
   }
 
   .hero {
-    position: relative;
+    /* See src/pages/index.astro for the rationale on grid-stacking +
+       content-height SVG. */
     isolation: isolate;
     min-block-size: 60svh;
     display: grid;
-    align-content: center;
     padding-block: var(--space-7);
   }
 
+  .hero > * {
+    grid-area: 1 / 1;
+    align-self: center;
+  }
+
   .hero__graph {
-    /* See src/pages/index.astro for the rationale on the ellipse mask. */
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
+    justify-self: stretch;
     z-index: -1;
+    pointer-events: none;
     overflow: hidden;
     -webkit-mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
             mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
@@ -109,6 +112,8 @@ try {
     display: grid;
     gap: var(--space-5);
     max-width: 56ch;
+    position: relative;
+    z-index: 1;
   }
 
   .hero__pitch {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,25 +93,30 @@ try {
   }
 
   .hero {
-    position: relative;
+    /* Stack `.hero__graph` and `.hero__type` in a single grid cell so the
+       graph sizes to its SVG's intrinsic aspect ratio (a thin horizontal
+       band) instead of being stretched to fill the entire 60svh hero
+       (which made the cells live in a small central strip surrounded by
+       empty SVG whitespace — the mask then mostly fell on the empty
+       region and the cells looked hard-edged). With grid stacking + an
+       SVG that's content-height, the mask draws on exactly the cell
+       band and the feather lands where intended. */
     isolation: isolate;
     min-block-size: 60svh;
     display: grid;
-    align-content: center;
     padding-block: var(--space-7);
   }
 
+  .hero > * {
+    grid-area: 1 / 1;
+    align-self: center;
+  }
+
   .hero__graph {
-    /* Name-aligned horizon: the grid fills the full hero bounds, then a
-       CSS ellipse mask reveals a wide horizontal band centered on the
-       name's eyeline. Asymmetric (70% × 60%) so the falloff is gentler
-       horizontally than vertically — type + texture as one composition.
-       The 35%/80% stops give a true opaque plateau + long soft fade
-       (matches the original Phase-0 prototype). */
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
+    /* Stretch horizontally; vertical size derives from the SVG inside. */
+    justify-self: stretch;
     z-index: -1;
+    pointer-events: none;
     overflow: hidden;
     -webkit-mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
             mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
@@ -121,6 +126,8 @@ try {
     display: grid;
     gap: var(--space-5);
     max-width: 56ch;
+    position: relative;
+    z-index: 1;
   }
 
   .hero__pitch {


### PR DESCRIPTION
Your diagnosis was exactly right — #41 moved the mask to an ellipse, but the underlying problem was the *box* the mask was being drawn on. `.hero__graph` was `position: absolute; inset: 0`, sized to the full 60svh hero, with the SVG inside set to `inline-size: 100%; block-size: 100%`. `preserveAspectRatio="xMidYMid meet"` then fit the actual cell grid into a small central strip of that giant container, leaving most of the SVG as empty whitespace. The mask drew on the container, so the soft-falloff region mostly fell on empty space and the cells themselves were near-fully opaque at the perception boundary — which is why it read as hard-edged even though the gradient stops were soft.

## Fix (your suggestion, applied)

Two coordinated changes:

1. **`.hero` becomes a single-cell grid.** `.hero__graph` and `.hero__type` share `grid-area: 1 / 1`, both `align-self: center`. The graph gets `justify-self: stretch` (horizontal fill); the type stays content-width with `z-index: 1` so it sits on top.

2. **`.contributions` drops `block-size: 100%`.** The SVG now renders at its intrinsic viewBox aspect ratio (~7.6:1, a thin horizontal band). With `inline-size: 100%` only, height comes from `width × (H/W)` of the viewBox. The container hugs the actual cells.

Net result: `.hero__graph`'s box is exactly the size of the visible cell band, so the ellipse mask lands on the cells themselves and the falloff matches the prototype 1:1.

```css
.hero {
  isolation: isolate;
  min-block-size: 60svh;
  display: grid;
  padding-block: var(--space-7);
}
.hero > * {
  grid-area: 1 / 1;
  align-self: center;
}
.hero__graph {
  justify-self: stretch;
  z-index: -1;
  pointer-events: none;
  overflow: hidden;
  mask-image: radial-gradient(ellipse 70% 60% at 80% 50%, #000 35%, transparent 80%);
}
.hero__type {
  /* ...content-width, z-index: 1 to sit above the graph */
}
```

## Diff scope

3 files, +36 / -18. Both `/en` and `/es` hero pages get the same treatment (es file's comment cross-refs the en rationale).

## Budgets

- Typecheck: 37 files, 0 issues ✓
- Build: 25 pages ✓
- Home gzip: CSS 5.88 KB (+0.15 KB), JS unchanged 7.27 KB — both under budget ✓

## Visual

Local screenshot now shows the cell band threading horizontally through the name's eyeline with even soft fade on all sides — same composition as the original Phase 0 prototype.

Side note: I noticed the `617 contributions · 0 streak` line is live in my local preview now, so the workflow is firing — nice. Streak is showing as 0 which is probably a calc edge case worth a separate look at some point but unrelated to this PR.

Follow-up to #41 — closes the visual gap that PR opened.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_