### PR TITLE
contrib: skip today's empty slot in streak calc

### DIFF
--- a/scripts/fetch-contributions.mjs
+++ b/scripts/fetch-contributions.mjs
@@ -107,13 +107,28 @@ function rebucketLevels(days) {
   });
 }
 
-/* Current streak = consecutive trailing days with count >= 1, walking backwards. */
+/*
+ * Current streak = consecutive trailing days with count >= 1, walking
+ * backwards from the latest day in the range.
+ *
+ * One exception: if *today* has 0 commits, don't treat that as a streak
+ * break — the workflow runs at 08:00 UTC (and ad-hoc dispatches can run
+ * any time), so "no commits yet today" is the normal state for most of
+ * a working day. We skip the trailing zero if and only if it's today,
+ * then count consecutive non-zero days from yesterday backwards. If
+ * yesterday is also zero, the streak is genuinely 0.
+ */
 function computeStreak(days) {
   const sorted = [...days].sort((a, b) => a.date.localeCompare(b.date));
+  if (sorted.length === 0) return 0;
+
+  let i = sorted.length - 1;
+  if (sorted[i].count === 0) i -= 1;
+
   let streak = 0;
-  for (let i = sorted.length - 1; i >= 0; i--) {
-    if (sorted[i].count > 0) streak += 1;
-    else break;
+  while (i >= 0 && sorted[i].count > 0) {
+    streak += 1;
+    i -= 1;
   }
   return streak;
 }


### PR DESCRIPTION
## Diagnosis

The hero showed `0 streak` even though the last two days had real activity (May 20: 57 commits, May 19: 23). Walking the actual `public/data/contributions.json` confirmed:

```
2026-05-19   23  L3
2026-05-20   57  L4
2026-05-21    0  L0   ← today, workflow ran at 04:45 UTC, no commits yet
```

`computeStreak` walked back from the most recent day in the range and `break`'d on the first zero count. Today (the most recent day) was zero, so the loop exited at iteration 0 with `streak = 0` — regardless of what was in the days before.

## Fix

Skip today's slot **only if** it's empty (you haven't committed yet — normal for most of a working day), then count consecutive non-zero days from yesterday backwards. If yesterday is also empty the streak is genuinely broken and we still return 0.

```diff
 function computeStreak(days) {
   const sorted = [...days].sort((a, b) => a.date.localeCompare(b.date));
-  let streak = 0;
-  for (let i = sorted.length - 1; i >= 0; i--) {
-    if (sorted[i].count > 0) streak += 1;
-    else break;
-  }
+  if (sorted.length === 0) return 0;
+
+  let i = sorted.length - 1;
+  if (sorted[i].count === 0) i -= 1;
+
+  let streak = 0;
+  while (i >= 0 && sorted[i].count > 0) {
+    streak += 1;
+    i -= 1;
+  }
   return streak;
 }
```

## Verification

Ran both versions against the current `public/data/contributions.json`:

```
old: 0 → new: 2
```

Matches reality (May 19 + May 20 = 2 consecutive non-zero days, broken by May 18 = 0).

## Scope

`scripts/fetch-contributions.mjs` only. 1 file, +19 / -4 (mostly the comment explaining the exception). Typecheck clean.

The next scheduled `sync-contributions` run will recompute and commit the corrected meta to `public/data/contributions.json`; or you can dispatch it manually after merging.

## Edge cases the new logic handles

- Today empty, yesterday non-zero → counts from yesterday back
- Today empty, yesterday also empty → returns 0 (genuine break)
- Today non-zero → counts from today back (unchanged behavior)
- Empty calendar → returns 0 (guard added)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_