### PR TITLE
ci: have sync-contributions dispatch the Pages deploy after a data commit

### DIFF
--- a/.github/workflows/sync-contributions.yml
+++ b/.github/workflows/sync-contributions.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  actions: write   # so the final step can dispatch deploy-pages.yml
 
 jobs:
   sync:
@@ -41,9 +42,11 @@ jobs:
         run: node scripts/fetch-contributions.mjs
 
       - name: Commit diff (if any)
+        id: commit
         run: |
           if [[ -z "$(git status --porcelain public/data/contributions.json)" ]]; then
             echo "No changes — contributions.json is up to date."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git config user.name  "github-actions[bot]"
@@ -51,3 +54,16 @@ jobs:
           git add public/data/contributions.json
           git commit -m "chore(data): sync contributions $(date -u +%Y-%m-%d)"
           git push
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Pages deploy
+        # Commits authored by GITHUB_TOKEN don't fire the `push` trigger on
+        # deploy-pages.yml (GitHub's loop-prevention rule), so a fresh JSON
+        # would otherwise sit on master until the next code push. Explicit
+        # workflow_dispatch IS allowed from GITHUB_TOKEN — fire it here so
+        # the home page rebuilds with the new totals every time the data
+        # actually changes.
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-pages.yml --ref master


### PR DESCRIPTION
## Why

The live site can sit on yesterday's totals indefinitely on days without code changes. The sync workflow uses `GITHUB_TOKEN` to push its contributions.json updates, and **GitHub Actions' loop-prevention rule blocks `push`-triggered workflows from firing on `GITHUB_TOKEN`-authored commits**. So the data moves forward on master, but `deploy-pages.yml`'s `on: push` trigger never sees it. The home page only rebuilds when something else (a code push, a manual dispatch) wakes the deploy workflow.

You spotted this when prod said `617` but the JSON on master had `629/630`.

## Fix

`workflow_dispatch` is one of the few events that `GITHUB_TOKEN` *can* trigger. So:

1. Capture whether the commit step actually committed (via a step output).
2. If yes, run `gh workflow run deploy-pages.yml --ref master` to dispatch the deploy.
3. If no (data unchanged), skip — no point in a pointless Pages rebuild.

Plus `actions: write` permission so the gh CLI can dispatch.

```diff
 permissions:
   contents: write
+  actions: write   # so the final step can dispatch deploy-pages.yml

       - name: Commit diff (if any)
+        id: commit
         run: |
           if [[ -z "$(git status --porcelain public/data/contributions.json)" ]]; then
             echo "No changes — contributions.json is up to date."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # ... commit + push ...
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Pages deploy
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-pages.yml --ref master
```

## After this lands

The chain on a real sync becomes:

```
cron fires
  → script runs
    → JSON commit pushed
      → deploy-pages dispatched
        → site rebuilt
          → live home page shows new totals
```

No-op syncs (data unchanged) skip the dispatch and don't trigger a Pages deploy — keeping the build queue clean.

## Scope

`.github/workflows/sync-contributions.yml` only. +16 / 0.

## Alternative considered

`workflow_run` trigger on deploy-pages.yml listening for sync-contributions completion — declarative, but you preferred the explicit dispatch since it keeps the cause-effect on one workflow file. Going with that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_