### PR TITLE
hero: pitch weight 300 + bring es homepage to parity

### DIFF
--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,13 +1,13 @@
 ---
-import Base from "~/layouts/Base.astro";
-import HeroName from "~/components/HeroName.astro";
-import WorkCard from "~/components/WorkCard.astro";
-import Contributions from "~/components/Contributions.astro";
-import ContributionsInteractive from "~/components/ContributionsInteractive.astro";
-import { listWorkForLocale } from "~/lib/content";
-import { t } from "~/lib/i18n";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import Contributions from "~/components/Contributions.astro";
+import ContributionsInteractive from "~/components/ContributionsInteractive.astro";
+import HeroName from "~/components/HeroName.astro";
+import WorkCard from "~/components/WorkCard.astro";
+import Base from "~/layouts/Base.astro";
+import { listWorkForLocale } from "~/lib/content";
+import { t } from "~/lib/i18n";
 
 const locale = "es";
 
@@ -112,11 +112,13 @@ try {
   }
 
   .hero__pitch {
-    font-family: var(--font-body);
+    font-family: var(--font-display);
+    font-style: italic;
     font-size: var(--type-21);
+    font-weight: 300;
     line-height: var(--line-snug);
-    color: var(--color-text-muted);
-    max-width: 32ch;
+    color: var(--color-text-default);
+    max-width: 30ch;
   }
 
   .hero__bio {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -123,6 +123,7 @@ try {
     font-family: var(--font-display);
     font-style: italic;
     font-size: var(--type-21);
+    font-weight: 300;
     line-height: var(--line-snug);
     color: var(--color-text-default);
     max-width: 30ch;


### PR DESCRIPTION
## Summary
Lightens the hero tagline with `font-weight: 300` so the italic Fraunces pitch reads as quiet support to the chromatic-split name rather than competing with it. Also brings the Spanish homepage's hero pitch up to parity with the English one shipped in #38 — same italic Fraunces, default text color, 30ch measure — so /es/ doesn't drift from /.

## Changes
- `index.astro`: add `font-weight: 300` to `.hero__pitch`
- `es/index.astro`: port the en pitch styling (`font-family: var(--font-display)`, `font-style: italic`, `color: var(--color-text-default)`, `max-width: 30ch`) + the new `font-weight: 300`; alphabetize the import block to match en

## Test plan
- [ ] Visit `/` — pitch reads lighter than before; no visible weight mismatch with surrounding type
- [ ] Visit `/es/` — pitch matches the en version's treatment (italic Fraunces, default color, weight 300)
- [ ] Confirm both locales render correctly in light and dark mode
- [ ] `pnpm typecheck` clean (verified locally)