### PR TITLE
i18n: render the fallback ribbon below the nav on /es/about + /es/colophon

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,14 @@
 ---
 import Base from "~/layouts/Base.astro";
+import FallbackRibbon from "~/components/FallbackRibbon.astro";
 import Prose from "~/components/Prose.astro";
+import type { Locale } from "~/lib/i18n";
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = "en" } = Astro.props;
 
 const beliefs = [
   "A design system is a *negotiation*, not a deliverable.",
@@ -20,6 +28,7 @@ const timeline = [
 ---
 
 <Base title="About — Luis Torres" description="Frontend engineer. I write code that pretends not to be there.">
+  {locale !== "en" && <FallbackRibbon locale={locale} />}
   <main class="about">
     <Prose>
       <h1>About</h1>

--- a/src/pages/colophon.astro
+++ b/src/pages/colophon.astro
@@ -1,6 +1,14 @@
 ---
 import Base from "~/layouts/Base.astro";
+import FallbackRibbon from "~/components/FallbackRibbon.astro";
 import Prose from "~/components/Prose.astro";
+import type { Locale } from "~/lib/i18n";
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = "en" } = Astro.props;
 ---
 
 <Base
@@ -8,6 +16,7 @@ import Prose from "~/components/Prose.astro";
   description="Architecture decisions and rationale — every load-bearing call that shaped this site, written down."
   transitions={false}
 >
+  {locale !== "en" && <FallbackRibbon locale={locale} />}
   <main class="colophon">
     <Prose>
       <h1>Colophon</h1>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -1,9 +1,5 @@
 ---
-import FallbackRibbon from "~/components/FallbackRibbon.astro";
 import About from "~/pages/about.astro";
-
-const locale = "es" as const;
 ---
 
-<FallbackRibbon locale={locale} />
-<About />
+<About locale="es" />

--- a/src/pages/es/colophon.astro
+++ b/src/pages/es/colophon.astro
@@ -1,9 +1,5 @@
 ---
-import FallbackRibbon from "~/components/FallbackRibbon.astro";
 import Colophon from "~/pages/colophon.astro";
-
-const locale = "es" as const;
 ---
 
-<FallbackRibbon locale={locale} />
-<Colophon />
+<Colophon locale="es" />


### PR DESCRIPTION
## Summary
- `/es/about` and `/es/colophon` rendered the "this page hasn't been translated yet" ribbon **above** the nav, while `/es/writing` and `/es/work` rendered it **below**. The user reported the inconsistency.
- Root cause: those two pages wrapped the English page-component and placed `<FallbackRibbon>` *outside* `<Base>`. In the source HTML the `<aside>` ended up before `<body>`; browsers tolerate stray content by moving it to the top of body — placing the ribbon above the nav.
- Fix: `about.astro` and `colophon.astro` now accept an optional `locale` prop and render `<FallbackRibbon>` *inside* `<Base>`, between `<Nav />` and `<main>`. The `/es` wrappers become `<About locale="es" />` and `<Colophon locale="es" />` (same pattern as the home-page collapse in #51).
- Order now matches across all `/es` pages: `body → nav → ribbon → main → footer`.

## Test plan
- [ ] `pnpm run build` → 30 pages built (verified locally)
- [ ] `pnpm run typecheck` → 0 errors (verified locally)
- [ ] Built HTML for `/es/about`, `/es/colophon`, `/es/writing`, `/es/work` all show: `<body>` → `<header class="nav">` → `<aside class="fallback-ribbon">` → `<main>` (verified locally)
- [ ] `/about` and `/colophon` (EN) render with no ribbon (verified locally)
- [ ] CI `audit:a11y` → 0 violations
- [ ] Manual: visit `/es/about` and `/es/colophon`, ribbon appears below the nav and the rest of the page renders normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_