### PR TITLE
theme-toggle: re-wire on astro:page-load so it survives view transitions

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -39,14 +39,21 @@ const { locale = (Astro.currentLocale as Locale | undefined) ?? "en" } = Astro.p
 </button>
 
 <script>
+  /*
+   * Re-wires on every astro:page-load — module scripts run once for the
+   * session, but ClientRouter swaps the document on navigation, leaving the
+   * post-swap button as a fresh node with no click listener and no
+   * data-current attribute (so it visually reverts to "auto" and stops
+   * responding). astro:page-load fires on the initial load *and* after
+   * every transition, so a single handler covers both cases.
+   *
+   * The document-level listener itself is attached once and persists across
+   * swaps; only the inner DOM lookups + click wiring need to repeat.
+   */
   type ThemeChoice = "auto" | "light" | "dark";
 
   const KEY = "theme";
   const ORDER: ThemeChoice[] = ["auto", "light", "dark"];
-
-  const root = document.documentElement;
-  const button = document.querySelector<HTMLButtonElement>("[data-theme-toggle]");
-  const label = document.querySelector<HTMLElement>("[data-theme-label]");
 
   function read(): ThemeChoice {
     try {
@@ -56,32 +63,41 @@ const { locale = (Astro.currentLocale as Locale | undefined) ?? "en" } = Astro.p
     return "auto";
   }
 
-  function apply(choice: ThemeChoice) {
-    if (choice === "auto") {
-      delete root.dataset.theme;
-      try { localStorage.removeItem(KEY); } catch (_) {}
-    } else {
-      root.dataset.theme = choice;
-      try { localStorage.setItem(KEY, choice); } catch (_) {}
-    }
-    if (label && button) {
-      const localized = button.getAttribute(`data-theme-label-${choice}`) ?? choice;
-      label.textContent = localized;
-      /* Keep aria-label in sync with the visible state so the accessible
-       * name contains the visible text (axe label-content-name-mismatch). */
-      const base = button.getAttribute("data-theme-label-aria") ?? "theme";
-      button.setAttribute("aria-label", `${base}: ${localized}`);
-    }
-    button?.setAttribute("data-current", choice);
+  function init() {
+    const root = document.documentElement;
+    const button = document.querySelector<HTMLButtonElement>("[data-theme-toggle]");
+    const label = document.querySelector<HTMLElement>("[data-theme-label]");
+    if (!button) return;
+
+    const apply = (choice: ThemeChoice) => {
+      if (choice === "auto") {
+        delete root.dataset.theme;
+        try { localStorage.removeItem(KEY); } catch (_) {}
+      } else {
+        root.dataset.theme = choice;
+        try { localStorage.setItem(KEY, choice); } catch (_) {}
+      }
+      if (label) {
+        const localized = button.getAttribute(`data-theme-label-${choice}`) ?? choice;
+        label.textContent = localized;
+        /* Keep aria-label in sync with the visible state so the accessible
+         * name contains the visible text (axe label-content-name-mismatch). */
+        const base = button.getAttribute("data-theme-label-aria") ?? "theme";
+        button.setAttribute("aria-label", `${base}: ${localized}`);
+      }
+      button.setAttribute("data-current", choice);
+    };
+
+    apply(read());
+
+    button.addEventListener("click", () => {
+      const current = read();
+      const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
+      apply(next);
+    });
   }
 
-  apply(read());
-
-  button?.addEventListener("click", () => {
-    const current = read();
-    const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
-    apply(next);
-  });
+  document.addEventListener("astro:page-load", init);
 </script>
 
 <style>


### PR DESCRIPTION
## Summary
**Bug:** Click theme toggle (e.g. auto → light) → click a nav item → toggle visually reverts to "auto" and stops responding.

**Root cause:** `ThemeToggle.astro`'s `<script>` ran its init code (DOM query, `data-current` apply, click listener) once at module load. `ClientRouter` swaps the document on navigation, so the post-swap button is a *fresh* DOM node with no listener attached and no `data-current` attribute — the server-rendered default ("auto") shows through, and clicks are dead. The actual `[data-theme]` on `<html>` stayed correct across swaps because `Base.astro`'s pre-paint script already handles `astro:before-swap`. Only the toggle's own UI state was stale.

**Fix:** wrap the per-button setup in `init()` and attach it to `astro:page-load`, which fires on the initial page load *and* after every transition. `LocaleSwitcher` already uses this pattern (`astro:after-swap`); this brings `ThemeToggle` in line.

## Test plan
- [ ] `pnpm run build` → 30 pages built (verified locally)
- [ ] `pnpm run typecheck` → 0 errors (verified locally)
- [ ] Repro the original bug: load `/`, click toggle (auto → light), click `work` in nav, confirm:
  - [ ] Toggle still shows "light" label and the `light` icon
  - [ ] Toggle has `data-current="light"`
  - [ ] Clicking the toggle now cycles `light → dark → auto → light…`
- [ ] Same flow but starting `auto → dark`
- [ ] Reload after navigation — stored preference persists and toggle reflects it
- [ ] CI `audit:a11y` → 0 violations

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkc1pyVbuEwzLVj514oEmX)_