### PR TITLE
theme-toggle: keep button in sync on pages that opt out of view transitions

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -44,11 +44,14 @@ const { locale = (Astro.currentLocale as Locale | undefined) ?? "en" } = Astro.p
    * session, but ClientRouter swaps the document on navigation, leaving the
    * post-swap button as a fresh node with no click listener and no
    * data-current attribute (so it visually reverts to "auto" and stops
-   * responding). astro:page-load fires on the initial load *and* after
-   * every transition, so a single handler covers both cases.
+   * responding). astro:page-load fires after every transition.
    *
-   * The document-level listener itself is attached once and persists across
-   * swaps; only the inner DOM lookups + click wiring need to repeat.
+   * astro:page-load is *not* a native event — it's emitted by ClientRouter.
+   * Pages that opt out of View Transitions (Base.astro `transitions={false}`)
+   * don't load the runtime, so we also run init on DOMContentLoaded /
+   * synchronously when the DOM is already ready. The click binding is
+   * guarded against double-wiring on transition-enabled initial loads where
+   * both paths fire.
    */
   type ThemeChoice = "auto" | "light" | "dark";
 
@@ -90,6 +93,8 @@ const { locale = (Astro.currentLocale as Locale | undefined) ?? "en" } = Astro.p
 
     apply(read());
 
+    if (button.dataset.themeToggleBound) return;
+    button.dataset.themeToggleBound = "1";
     button.addEventListener("click", () => {
       const current = read();
       const next = ORDER[(ORDER.indexOf(current) + 1) % ORDER.length];
@@ -97,6 +102,11 @@ const { locale = (Astro.currentLocale as Locale | undefined) ?? "en" } = Astro.p
     });
   }
 
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
   document.addEventListener("astro:page-load", init);
 </script>
 


### PR DESCRIPTION
## Summary

Fixes a UI desync where switching the theme to "light" (or "dark") and then navigating to `/colophon` made the toggle button revert to "auto", even though the page itself still rendered in the chosen theme.

## Root cause

`ThemeToggle.astro` wired its `init()` exclusively to `astro:page-load`, which is emitted by Astro's ClientRouter — not a native event. `/colophon` opts out of View Transitions (`transitions={false}` at `colophon.astro:17`), so ClientRouter isn't loaded there and `astro:page-load` never fires. The pre-paint script in `Base.astro` still applied `<html data-theme="light">`, so the page colors were right, but the toggle's `[data-current]` attribute was never set and the CSS at `ThemeToggle.astro:141-143` falls back to the "auto" icon when that attribute is missing.

The same bug was latent on any other `transitions={false}` page (e.g. `/theme`, `/404`).

## Fix

In `src/components/ThemeToggle.astro`:

- Also run `init()` synchronously when the DOM is already parsed, otherwise on `DOMContentLoaded`. Keep the `astro:page-load` listener for ClientRouter swaps.
- Guard the click binding with `button.dataset.themeToggleBound` so transition-enabled initial loads (where both paths fire) don't double-bind.

## Test plan

- [ ] On `/` (transitions on), toggle to "light" — button reads "○ light", `<html data-theme="light">`.
- [ ] Navigate to `/colophon` — button still reads "○ light", page is in light mode.
- [ ] Click back to `/` and to `/work` — toggle stays in sync.
- [ ] Click toggle once on each page — advances exactly one state (verifies click handler isn't double-bound).
- [ ] Repeat with "dark", and with system pref set to dark while toggle is "auto".
- [ ] Hard-refresh directly on `/colophon` — toggle reflects stored choice immediately, no "auto" flash.
- [ ] `pnpm typecheck` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9t9nsP87Jye9yjy1jmqnn)_