### PR TITLE
refactor(styles): split radii tokens out of space.css

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -5,6 +5,7 @@
 @import "./theme/semantic.css" layer(theme);
 @import "./theme/typography.css" layer(theme);
 @import "./theme/space.css" layer(theme);
+@import "./theme/radii.css" layer(theme);
 @import "./theme/motion.css" layer(theme);
 @import "./theme/fonts.css" layer(theme);
 @import "./base.css" layer(base);

--- a/src/styles/theme/radii.css
+++ b/src/styles/theme/radii.css
@@ -1,0 +1,10 @@
+/*
+ * Corner-radius scale. Discrete steps; mix per surface (cards, inputs, pills).
+ */
+
+:root {
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   16px;
+  --radius-pill: 9999px;
+}

--- a/src/styles/theme/space.css
+++ b/src/styles/theme/space.css
@@ -16,11 +16,6 @@
   --space-10: 8rem;    /* 128 */
   --space-11: 12rem;   /* 192 */
 
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 16px;
-  --radius-pill: 9999px;
-
   --container-narrow: 36rem;
   --container-prose:  44rem;
   --container-wide:   72rem;


### PR DESCRIPTION
## Summary
- New `src/styles/theme/radii.css` holds `--radius-sm/md/lg/pill`.
- Removed the same block from `space.css`.
- Imported in `src/styles/index.css` between `space.css` and `motion.css`.

## Why
PLAN §4 lists radii as its own token file. Same scale, separate concern — keeps `space.css` focused on linear spatial tokens. No value changes.

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm build:astro` — 32 pages built, no warnings
- [ ] CI green