### PR TITLE
feat(styles): add elevation tokens with light-dark() shadows

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -6,5 +6,6 @@
 @import "./theme/typography.css" layer(theme);
 @import "./theme/space.css" layer(theme);
 @import "./theme/motion.css" layer(theme);
+@import "./theme/elevation.css" layer(theme);
 @import "./theme/fonts.css" layer(theme);
 @import "./base.css" layer(base);

--- a/src/styles/theme/elevation.css
+++ b/src/styles/theme/elevation.css
@@ -1,12 +1,13 @@
 /*
- * Elevation tokens. Shadows derive from a single semantic --color-shadow
- * and a strength scale, so each shadow layers the same hue at different
- * alphas and stays tunable from one knob. Use sparingly — the system
+ * Elevation tokens. Every shadow derives from a single --shadow-color and a
+ * --shadow-strength scale, so each level stacks the same hue at calculated
+ * alphas — tunable from one knob and correct in both schemes. Levels run
+ * --shadow-1 (subtle) → --shadow-6 (lifted). Use sparingly — the system
  * leans flat.
  */
 
 :root {
-  --color-shadow: light-dark(hsl(220 3% 15%), hsl(220 40% 2%));
+  --shadow-color: light-dark(hsl(220 3% 15%), hsl(220 40% 2%));
 
   --shadow-strength: 1%;
   --shadow-strength-3: calc(var(--shadow-strength) + 2%);
@@ -17,8 +18,36 @@
   --shadow-strength-8: calc(var(--shadow-strength) + 7%);
   --shadow-strength-10: calc(var(--shadow-strength) + 9%);
 
-  --shadow-sm: 0 1px 2px -1px hsl(from var(--color-shadow) h s l / var(--shadow-strength-10));
-  --shadow-md:
-    0 3px 5px -2px hsl(from var(--color-shadow) h s l / var(--shadow-strength-4)),
-    0 7px 14px -5px hsl(from var(--color-shadow) h s l / var(--shadow-strength-6));
+  --shadow-1: 0 1px 2px -1px hsl(from var(--shadow-color) h s l / var(--shadow-strength-10));
+  --shadow-2:
+    0 3px 5px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 7px 14px -5px hsl(from var(--shadow-color) h s l / var(--shadow-strength-6));
+  --shadow-3:
+    0 -1px 3px 0 hsl(from var(--shadow-color) h s l / var(--shadow-strength-3)),
+    0 1px 2px -5px hsl(from var(--shadow-color) h s l / var(--shadow-strength-3)),
+    0 2px 5px -5px hsl(from var(--shadow-color) h s l / var(--shadow-strength-5)),
+    0 4px 12px -5px hsl(from var(--shadow-color) h s l / var(--shadow-strength-6)),
+    0 12px 15px -5px hsl(from var(--shadow-color) h s l / var(--shadow-strength-8));
+  --shadow-4:
+    0 -2px 5px 0 hsl(from var(--shadow-color) h s l / var(--shadow-strength-3)),
+    0 1px 1px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 2px 2px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 5px 5px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-5)),
+    0 9px 9px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-6)),
+    0 16px 16px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-7));
+  --shadow-5:
+    0 -1px 2px 0 hsl(from var(--shadow-color) h s l / var(--shadow-strength-3)),
+    0 2px 1px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 5px 5px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 10px 10px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-5)),
+    0 20px 20px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-6)),
+    0 40px 40px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-8));
+  --shadow-6:
+    0 -1px 2px 0 hsl(from var(--shadow-color) h s l / var(--shadow-strength-3)),
+    0 3px 2px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 7px 5px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-4)),
+    0 12px 10px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-5)),
+    0 22px 18px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-6)),
+    0 41px 33px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-7)),
+    0 100px 80px -2px hsl(from var(--shadow-color) h s l / var(--shadow-strength-8));
 }

--- a/src/styles/theme/elevation.css
+++ b/src/styles/theme/elevation.css
@@ -1,9 +1,24 @@
 /*
- * Elevation tokens. Soft, dual-mode shadows via light-dark() so a single
- * declaration handles both schemes. Use sparingly — the system leans flat.
+ * Elevation tokens. Shadows derive from a single semantic --color-shadow
+ * and a strength scale, so each shadow layers the same hue at different
+ * alphas and stays tunable from one knob. Use sparingly — the system
+ * leans flat.
  */
 
 :root {
-  --shadow-sm: 0 1px 2px light-dark(rgb(0 0 0 / 0.06), rgb(0 0 0 / 0.4));
-  --shadow-md: 0 8px 24px -8px light-dark(rgb(0 0 0 / 0.12), rgb(0 0 0 / 0.6));
+  --color-shadow: light-dark(hsl(220 3% 15%), hsl(220 40% 2%));
+
+  --shadow-strength: 1%;
+  --shadow-strength-3: calc(var(--shadow-strength) + 2%);
+  --shadow-strength-4: calc(var(--shadow-strength) + 3%);
+  --shadow-strength-5: calc(var(--shadow-strength) + 4%);
+  --shadow-strength-6: calc(var(--shadow-strength) + 5%);
+  --shadow-strength-7: calc(var(--shadow-strength) + 6%);
+  --shadow-strength-8: calc(var(--shadow-strength) + 7%);
+  --shadow-strength-10: calc(var(--shadow-strength) + 9%);
+
+  --shadow-sm: 0 1px 2px -1px hsl(from var(--color-shadow) h s l / var(--shadow-strength-10));
+  --shadow-md:
+    0 3px 5px -2px hsl(from var(--color-shadow) h s l / var(--shadow-strength-4)),
+    0 7px 14px -5px hsl(from var(--color-shadow) h s l / var(--shadow-strength-6));
 }

--- a/src/styles/theme/elevation.css
+++ b/src/styles/theme/elevation.css
@@ -1,0 +1,9 @@
+/*
+ * Elevation tokens. Soft, dual-mode shadows via light-dark() so a single
+ * declaration handles both schemes. Use sparingly — the system leans flat.
+ */
+
+:root {
+  --shadow-sm: 0 1px 2px light-dark(rgb(0 0 0 / 0.06), rgb(0 0 0 / 0.4));
+  --shadow-md: 0 8px 24px -8px light-dark(rgb(0 0 0 / 0.12), rgb(0 0 0 / 0.6));
+}


### PR DESCRIPTION
## Summary
- New `src/styles/theme/elevation.css` defines `--shadow-sm` and `--shadow-md`.
- Both use `light-dark()` so a single declaration handles both color schemes.
- Imported in `src/styles/index.css` after `motion.css`, before `fonts.css`.

## Why
PLAN §4 specifies these tokens. No consumers yet — adding them so they're available for cards, raised surfaces, and future hover states without ad-hoc shadow values landing in components.

## Test plan
- [x] `pnpm build:astro` — 32 pages built, no warnings
- [ ] CI green