### PR TITLE
feat(styles): scaffold atoms layer

### DIFF
--- a/src/styles/atoms/layout.css
+++ b/src/styles/atoms/layout.css
@@ -1,7 +1,7 @@
 /*
  * Layout atoms. Composable flex/grid primitives + width containers.
- * Each accepts a per-instance gap override via a scoped custom prop —
- * e.g. <div class="column" style="--column-gap: var(--space-3)"> .
+ * Gap is opt-in at the call site — atoms ship without a default gap so
+ * consumers don't have to "undo" one they didn't ask for.
  *
  * Lives in the `atoms` layer so utility overrides on a component instance
  * always win without specificity gymnastics.
@@ -10,35 +10,20 @@
 .column {
   display: flex;
   flex-direction: column;
-  gap: var(--column-gap, var(--space-5));
 }
 
 .row {
   display: flex;
   flex-direction: row;
-  gap: var(--row-gap, var(--space-4));
-}
-
-.cluster {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cluster-gap, var(--space-3));
 }
 
 .grid {
   display: grid;
-  gap: var(--grid-gap, var(--space-5));
 }
 
 .grid-auto-fit {
   display: grid;
-  gap: var(--grid-gap, var(--space-5));
   grid-template-columns: repeat(auto-fit, minmax(var(--min-col, 16rem), 1fr));
-}
-
-.center {
-  display: grid;
-  place-items: center;
 }
 
 .flex { display: flex; }

--- a/src/styles/atoms/layout.css
+++ b/src/styles/atoms/layout.css
@@ -1,0 +1,67 @@
+/*
+ * Layout atoms. Composable flex/grid primitives + width containers.
+ * Each accepts a per-instance gap override via a scoped custom prop —
+ * e.g. <div class="column" style="--column-gap: var(--space-3)"> .
+ *
+ * Lives in the `atoms` layer so utility overrides on a component instance
+ * always win without specificity gymnastics.
+ */
+
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--column-gap, var(--space-5));
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  gap: var(--row-gap, var(--space-4));
+}
+
+.cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cluster-gap, var(--space-3));
+}
+
+.grid {
+  display: grid;
+  gap: var(--grid-gap, var(--space-5));
+}
+
+.grid-auto-fit {
+  display: grid;
+  gap: var(--grid-gap, var(--space-5));
+  grid-template-columns: repeat(auto-fit, minmax(var(--min-col, 16rem), 1fr));
+}
+
+.center {
+  display: grid;
+  place-items: center;
+}
+
+.flex { display: flex; }
+.wrap { flex-wrap: wrap; }
+.fill { flex: 1 1 0; }
+
+/* Width containers — reuse the existing --container-* tokens. */
+.container {
+  max-inline-size: var(--measure-page, var(--container-wide));
+  margin-inline: auto;
+}
+
+.container-prose {
+  max-inline-size: var(--measure-prose, var(--container-prose));
+  margin-inline: auto;
+}
+
+.container-narrow {
+  max-inline-size: var(--measure-narrow, var(--container-narrow));
+  margin-inline: auto;
+}
+
+.container-wide {
+  max-inline-size: var(--measure-wide, 100rem);
+  margin-inline: auto;
+}

--- a/src/styles/atoms/motion.css
+++ b/src/styles/atoms/motion.css
@@ -1,0 +1,35 @@
+/*
+ * Motion + accessibility atoms.
+ *
+ * .sr-only      — visually hide an element while keeping it in the a11y tree.
+ * .motion-safe  — children with this class only animate when the user has
+ *                 NOT requested reduced motion. Pair with your animation
+ *                 declaration; the atom only opts in, it does not declare.
+ */
+
+.sr-only {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.not-sr-only {
+  position: static;
+  inline-size: auto;
+  block-size: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .motion-safe { animation: none !important; transition: none !important; }
+}

--- a/src/styles/atoms/spacing.css
+++ b/src/styles/atoms/spacing.css
@@ -1,0 +1,191 @@
+/*
+ * Spacing atoms. One class per token step × direction.
+ * Padding: p, px, py, pt, pr, pb, pl.
+ * Margin:  m, mx, my, mt, mr, mb, ml.
+ * Steps 1–11 mirror the --space-* scale; step 0 is a literal 0 escape hatch.
+ */
+
+.p-0  { padding: 0; }
+.p-1  { padding: var(--space-1); }
+.p-2  { padding: var(--space-2); }
+.p-3  { padding: var(--space-3); }
+.p-4  { padding: var(--space-4); }
+.p-5  { padding: var(--space-5); }
+.p-6  { padding: var(--space-6); }
+.p-7  { padding: var(--space-7); }
+.p-8  { padding: var(--space-8); }
+.p-9  { padding: var(--space-9); }
+.p-10 { padding: var(--space-10); }
+.p-11 { padding: var(--space-11); }
+
+.px-0  { padding-inline: 0; }
+.px-1  { padding-inline: var(--space-1); }
+.px-2  { padding-inline: var(--space-2); }
+.px-3  { padding-inline: var(--space-3); }
+.px-4  { padding-inline: var(--space-4); }
+.px-5  { padding-inline: var(--space-5); }
+.px-6  { padding-inline: var(--space-6); }
+.px-7  { padding-inline: var(--space-7); }
+.px-8  { padding-inline: var(--space-8); }
+.px-9  { padding-inline: var(--space-9); }
+.px-10 { padding-inline: var(--space-10); }
+.px-11 { padding-inline: var(--space-11); }
+
+.py-0  { padding-block: 0; }
+.py-1  { padding-block: var(--space-1); }
+.py-2  { padding-block: var(--space-2); }
+.py-3  { padding-block: var(--space-3); }
+.py-4  { padding-block: var(--space-4); }
+.py-5  { padding-block: var(--space-5); }
+.py-6  { padding-block: var(--space-6); }
+.py-7  { padding-block: var(--space-7); }
+.py-8  { padding-block: var(--space-8); }
+.py-9  { padding-block: var(--space-9); }
+.py-10 { padding-block: var(--space-10); }
+.py-11 { padding-block: var(--space-11); }
+
+.pt-0  { padding-block-start: 0; }
+.pt-1  { padding-block-start: var(--space-1); }
+.pt-2  { padding-block-start: var(--space-2); }
+.pt-3  { padding-block-start: var(--space-3); }
+.pt-4  { padding-block-start: var(--space-4); }
+.pt-5  { padding-block-start: var(--space-5); }
+.pt-6  { padding-block-start: var(--space-6); }
+.pt-7  { padding-block-start: var(--space-7); }
+.pt-8  { padding-block-start: var(--space-8); }
+.pt-9  { padding-block-start: var(--space-9); }
+.pt-10 { padding-block-start: var(--space-10); }
+.pt-11 { padding-block-start: var(--space-11); }
+
+.pb-0  { padding-block-end: 0; }
+.pb-1  { padding-block-end: var(--space-1); }
+.pb-2  { padding-block-end: var(--space-2); }
+.pb-3  { padding-block-end: var(--space-3); }
+.pb-4  { padding-block-end: var(--space-4); }
+.pb-5  { padding-block-end: var(--space-5); }
+.pb-6  { padding-block-end: var(--space-6); }
+.pb-7  { padding-block-end: var(--space-7); }
+.pb-8  { padding-block-end: var(--space-8); }
+.pb-9  { padding-block-end: var(--space-9); }
+.pb-10 { padding-block-end: var(--space-10); }
+.pb-11 { padding-block-end: var(--space-11); }
+
+.pl-0  { padding-inline-start: 0; }
+.pl-1  { padding-inline-start: var(--space-1); }
+.pl-2  { padding-inline-start: var(--space-2); }
+.pl-3  { padding-inline-start: var(--space-3); }
+.pl-4  { padding-inline-start: var(--space-4); }
+.pl-5  { padding-inline-start: var(--space-5); }
+.pl-6  { padding-inline-start: var(--space-6); }
+.pl-7  { padding-inline-start: var(--space-7); }
+.pl-8  { padding-inline-start: var(--space-8); }
+.pl-9  { padding-inline-start: var(--space-9); }
+.pl-10 { padding-inline-start: var(--space-10); }
+.pl-11 { padding-inline-start: var(--space-11); }
+
+.pr-0  { padding-inline-end: 0; }
+.pr-1  { padding-inline-end: var(--space-1); }
+.pr-2  { padding-inline-end: var(--space-2); }
+.pr-3  { padding-inline-end: var(--space-3); }
+.pr-4  { padding-inline-end: var(--space-4); }
+.pr-5  { padding-inline-end: var(--space-5); }
+.pr-6  { padding-inline-end: var(--space-6); }
+.pr-7  { padding-inline-end: var(--space-7); }
+.pr-8  { padding-inline-end: var(--space-8); }
+.pr-9  { padding-inline-end: var(--space-9); }
+.pr-10 { padding-inline-end: var(--space-10); }
+.pr-11 { padding-inline-end: var(--space-11); }
+
+.m-0  { margin: 0; }
+.m-1  { margin: var(--space-1); }
+.m-2  { margin: var(--space-2); }
+.m-3  { margin: var(--space-3); }
+.m-4  { margin: var(--space-4); }
+.m-5  { margin: var(--space-5); }
+.m-6  { margin: var(--space-6); }
+.m-7  { margin: var(--space-7); }
+.m-8  { margin: var(--space-8); }
+.m-9  { margin: var(--space-9); }
+.m-10 { margin: var(--space-10); }
+.m-11 { margin: var(--space-11); }
+
+.mx-0    { margin-inline: 0; }
+.mx-auto { margin-inline: auto; }
+.mx-1  { margin-inline: var(--space-1); }
+.mx-2  { margin-inline: var(--space-2); }
+.mx-3  { margin-inline: var(--space-3); }
+.mx-4  { margin-inline: var(--space-4); }
+.mx-5  { margin-inline: var(--space-5); }
+.mx-6  { margin-inline: var(--space-6); }
+.mx-7  { margin-inline: var(--space-7); }
+.mx-8  { margin-inline: var(--space-8); }
+.mx-9  { margin-inline: var(--space-9); }
+.mx-10 { margin-inline: var(--space-10); }
+.mx-11 { margin-inline: var(--space-11); }
+
+.my-0  { margin-block: 0; }
+.my-1  { margin-block: var(--space-1); }
+.my-2  { margin-block: var(--space-2); }
+.my-3  { margin-block: var(--space-3); }
+.my-4  { margin-block: var(--space-4); }
+.my-5  { margin-block: var(--space-5); }
+.my-6  { margin-block: var(--space-6); }
+.my-7  { margin-block: var(--space-7); }
+.my-8  { margin-block: var(--space-8); }
+.my-9  { margin-block: var(--space-9); }
+.my-10 { margin-block: var(--space-10); }
+.my-11 { margin-block: var(--space-11); }
+
+.mt-0  { margin-block-start: 0; }
+.mt-1  { margin-block-start: var(--space-1); }
+.mt-2  { margin-block-start: var(--space-2); }
+.mt-3  { margin-block-start: var(--space-3); }
+.mt-4  { margin-block-start: var(--space-4); }
+.mt-5  { margin-block-start: var(--space-5); }
+.mt-6  { margin-block-start: var(--space-6); }
+.mt-7  { margin-block-start: var(--space-7); }
+.mt-8  { margin-block-start: var(--space-8); }
+.mt-9  { margin-block-start: var(--space-9); }
+.mt-10 { margin-block-start: var(--space-10); }
+.mt-11 { margin-block-start: var(--space-11); }
+
+.mb-0  { margin-block-end: 0; }
+.mb-1  { margin-block-end: var(--space-1); }
+.mb-2  { margin-block-end: var(--space-2); }
+.mb-3  { margin-block-end: var(--space-3); }
+.mb-4  { margin-block-end: var(--space-4); }
+.mb-5  { margin-block-end: var(--space-5); }
+.mb-6  { margin-block-end: var(--space-6); }
+.mb-7  { margin-block-end: var(--space-7); }
+.mb-8  { margin-block-end: var(--space-8); }
+.mb-9  { margin-block-end: var(--space-9); }
+.mb-10 { margin-block-end: var(--space-10); }
+.mb-11 { margin-block-end: var(--space-11); }
+
+.ml-0   { margin-inline-start: 0; }
+.ml-auto { margin-inline-start: auto; }
+.ml-1   { margin-inline-start: var(--space-1); }
+.ml-2   { margin-inline-start: var(--space-2); }
+.ml-3   { margin-inline-start: var(--space-3); }
+.ml-4   { margin-inline-start: var(--space-4); }
+.ml-5   { margin-inline-start: var(--space-5); }
+.ml-6   { margin-inline-start: var(--space-6); }
+.ml-7   { margin-inline-start: var(--space-7); }
+.ml-8   { margin-inline-start: var(--space-8); }
+.ml-9   { margin-inline-start: var(--space-9); }
+.ml-10  { margin-inline-start: var(--space-10); }
+.ml-11  { margin-inline-start: var(--space-11); }
+
+.mr-0   { margin-inline-end: 0; }
+.mr-auto { margin-inline-end: auto; }
+.mr-1   { margin-inline-end: var(--space-1); }
+.mr-2   { margin-inline-end: var(--space-2); }
+.mr-3   { margin-inline-end: var(--space-3); }
+.mr-4   { margin-inline-end: var(--space-4); }
+.mr-5   { margin-inline-end: var(--space-5); }
+.mr-6   { margin-inline-end: var(--space-6); }
+.mr-7   { margin-inline-end: var(--space-7); }
+.mr-8   { margin-inline-end: var(--space-8); }
+.mr-9   { margin-inline-end: var(--space-9); }
+.mr-10  { margin-inline-end: var(--space-10); }
+.mr-11  { margin-inline-end: var(--space-11); }

--- a/src/styles/atoms/spacing.css
+++ b/src/styles/atoms/spacing.css
@@ -1,7 +1,7 @@
 /*
  * Spacing atoms. One class per token step × direction.
- * Padding: p, px, py, pt, pr, pb, pl.
- * Margin:  m, mx, my, mt, mr, mb, ml.
+ * Padding: p, px, py, pt, pe, pb, ps.
+ * Margin:  m, mx, my, mt, me, mb, ms.
  * Steps 1–11 mirror the --space-* scale; step 0 is a literal 0 escape hatch.
  */
 
@@ -70,31 +70,31 @@
 .pb-10 { padding-block-end: var(--space-10); }
 .pb-11 { padding-block-end: var(--space-11); }
 
-.pl-0  { padding-inline-start: 0; }
-.pl-1  { padding-inline-start: var(--space-1); }
-.pl-2  { padding-inline-start: var(--space-2); }
-.pl-3  { padding-inline-start: var(--space-3); }
-.pl-4  { padding-inline-start: var(--space-4); }
-.pl-5  { padding-inline-start: var(--space-5); }
-.pl-6  { padding-inline-start: var(--space-6); }
-.pl-7  { padding-inline-start: var(--space-7); }
-.pl-8  { padding-inline-start: var(--space-8); }
-.pl-9  { padding-inline-start: var(--space-9); }
-.pl-10 { padding-inline-start: var(--space-10); }
-.pl-11 { padding-inline-start: var(--space-11); }
+.ps-0  { padding-inline-start: 0; }
+.ps-1  { padding-inline-start: var(--space-1); }
+.ps-2  { padding-inline-start: var(--space-2); }
+.ps-3  { padding-inline-start: var(--space-3); }
+.ps-4  { padding-inline-start: var(--space-4); }
+.ps-5  { padding-inline-start: var(--space-5); }
+.ps-6  { padding-inline-start: var(--space-6); }
+.ps-7  { padding-inline-start: var(--space-7); }
+.ps-8  { padding-inline-start: var(--space-8); }
+.ps-9  { padding-inline-start: var(--space-9); }
+.ps-10 { padding-inline-start: var(--space-10); }
+.ps-11 { padding-inline-start: var(--space-11); }
 
-.pr-0  { padding-inline-end: 0; }
-.pr-1  { padding-inline-end: var(--space-1); }
-.pr-2  { padding-inline-end: var(--space-2); }
-.pr-3  { padding-inline-end: var(--space-3); }
-.pr-4  { padding-inline-end: var(--space-4); }
-.pr-5  { padding-inline-end: var(--space-5); }
-.pr-6  { padding-inline-end: var(--space-6); }
-.pr-7  { padding-inline-end: var(--space-7); }
-.pr-8  { padding-inline-end: var(--space-8); }
-.pr-9  { padding-inline-end: var(--space-9); }
-.pr-10 { padding-inline-end: var(--space-10); }
-.pr-11 { padding-inline-end: var(--space-11); }
+.pe-0  { padding-inline-end: 0; }
+.pe-1  { padding-inline-end: var(--space-1); }
+.pe-2  { padding-inline-end: var(--space-2); }
+.pe-3  { padding-inline-end: var(--space-3); }
+.pe-4  { padding-inline-end: var(--space-4); }
+.pe-5  { padding-inline-end: var(--space-5); }
+.pe-6  { padding-inline-end: var(--space-6); }
+.pe-7  { padding-inline-end: var(--space-7); }
+.pe-8  { padding-inline-end: var(--space-8); }
+.pe-9  { padding-inline-end: var(--space-9); }
+.pe-10 { padding-inline-end: var(--space-10); }
+.pe-11 { padding-inline-end: var(--space-11); }
 
 .m-0  { margin: 0; }
 .m-1  { margin: var(--space-1); }
@@ -162,30 +162,30 @@
 .mb-10 { margin-block-end: var(--space-10); }
 .mb-11 { margin-block-end: var(--space-11); }
 
-.ml-0   { margin-inline-start: 0; }
-.ml-auto { margin-inline-start: auto; }
-.ml-1   { margin-inline-start: var(--space-1); }
-.ml-2   { margin-inline-start: var(--space-2); }
-.ml-3   { margin-inline-start: var(--space-3); }
-.ml-4   { margin-inline-start: var(--space-4); }
-.ml-5   { margin-inline-start: var(--space-5); }
-.ml-6   { margin-inline-start: var(--space-6); }
-.ml-7   { margin-inline-start: var(--space-7); }
-.ml-8   { margin-inline-start: var(--space-8); }
-.ml-9   { margin-inline-start: var(--space-9); }
-.ml-10  { margin-inline-start: var(--space-10); }
-.ml-11  { margin-inline-start: var(--space-11); }
+.ms-0   { margin-inline-start: 0; }
+.ms-auto { margin-inline-start: auto; }
+.ms-1   { margin-inline-start: var(--space-1); }
+.ms-2   { margin-inline-start: var(--space-2); }
+.ms-3   { margin-inline-start: var(--space-3); }
+.ms-4   { margin-inline-start: var(--space-4); }
+.ms-5   { margin-inline-start: var(--space-5); }
+.ms-6   { margin-inline-start: var(--space-6); }
+.ms-7   { margin-inline-start: var(--space-7); }
+.ms-8   { margin-inline-start: var(--space-8); }
+.ms-9   { margin-inline-start: var(--space-9); }
+.ms-10  { margin-inline-start: var(--space-10); }
+.ms-11  { margin-inline-start: var(--space-11); }
 
-.mr-0   { margin-inline-end: 0; }
-.mr-auto { margin-inline-end: auto; }
-.mr-1   { margin-inline-end: var(--space-1); }
-.mr-2   { margin-inline-end: var(--space-2); }
-.mr-3   { margin-inline-end: var(--space-3); }
-.mr-4   { margin-inline-end: var(--space-4); }
-.mr-5   { margin-inline-end: var(--space-5); }
-.mr-6   { margin-inline-end: var(--space-6); }
-.mr-7   { margin-inline-end: var(--space-7); }
-.mr-8   { margin-inline-end: var(--space-8); }
-.mr-9   { margin-inline-end: var(--space-9); }
-.mr-10  { margin-inline-end: var(--space-10); }
-.mr-11  { margin-inline-end: var(--space-11); }
+.me-0   { margin-inline-end: 0; }
+.me-auto { margin-inline-end: auto; }
+.me-1   { margin-inline-end: var(--space-1); }
+.me-2   { margin-inline-end: var(--space-2); }
+.me-3   { margin-inline-end: var(--space-3); }
+.me-4   { margin-inline-end: var(--space-4); }
+.me-5   { margin-inline-end: var(--space-5); }
+.me-6   { margin-inline-end: var(--space-6); }
+.me-7   { margin-inline-end: var(--space-7); }
+.me-8   { margin-inline-end: var(--space-8); }
+.me-9   { margin-inline-end: var(--space-9); }
+.me-10  { margin-inline-end: var(--space-10); }
+.me-11  { margin-inline-end: var(--space-11); }

--- a/src/styles/atoms/typography.css
+++ b/src/styles/atoms/typography.css
@@ -1,0 +1,45 @@
+/*
+ * Typography atoms. Family, weight, alignment, leading, tracking, and the
+ * fluid size scale exposed as single-purpose utilities. Mirrors the tokens
+ * in theme/typography.css 1:1 so authoring stays consistent.
+ */
+
+.font-display { font-family: var(--font-display); }
+.font-body    { font-family: var(--font-body); }
+.font-mono    { font-family: var(--font-mono); }
+
+.text-xs   { font-size: var(--font-size-xs); }
+.text-sm   { font-size: var(--font-size-sm); }
+.text-base { font-size: var(--font-size-base); }
+.text-md   { font-size: var(--font-size-md); }
+.text-lg   { font-size: var(--font-size-lg); }
+.text-xl   { font-size: var(--font-size-xl); }
+.text-2xl  { font-size: var(--font-size-2xl); }
+.text-3xl  { font-size: var(--font-size-3xl); }
+.text-4xl  { font-size: var(--font-size-4xl); }
+
+.leading-tight   { line-height: var(--line-tight); }
+.leading-snug    { line-height: var(--line-snug); }
+.leading-default { line-height: var(--line-default); }
+.leading-loose   { line-height: var(--line-loose); }
+
+.tracking-tight   { letter-spacing: var(--tracking-tight); }
+.tracking-default { letter-spacing: var(--tracking-default); }
+.tracking-wide    { letter-spacing: var(--tracking-wide); }
+
+.text-start  { text-align: start; }
+.text-center { text-align: center; }
+.text-end    { text-align: end; }
+.text-balance { text-wrap: balance; }
+.text-pretty  { text-wrap: pretty; }
+
+.uppercase  { text-transform: uppercase; }
+.lowercase  { text-transform: lowercase; }
+.capitalize { text-transform: capitalize; }
+.normal-case { text-transform: none; }
+
+.text-default { color: var(--color-text-default); }
+.text-subdued { color: var(--color-text-subdued); }
+.text-faint   { color: var(--color-text-faint); }
+.text-inverse { color: var(--color-text-inverse); }
+.text-accent  { color: var(--color-text-accent); }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -8,3 +8,7 @@
 @import "./theme/motion.css" layer(theme);
 @import "./theme/fonts.css" layer(theme);
 @import "./base.css" layer(base);
+@import "./atoms/layout.css" layer(atoms);
+@import "./atoms/spacing.css" layer(atoms);
+@import "./atoms/typography.css" layer(atoms);
+@import "./atoms/motion.css" layer(atoms);


### PR DESCRIPTION
## Summary
Adds four files under `src/styles/atoms/` to populate the empty `@layer atoms` cascade:

| File | What |
|---|---|
| `layout.css` | `.column .row .cluster .grid .grid-auto-fit .center .flex .wrap .fill` + `.container*` width clamps. Each accepts a per-instance gap override via scoped custom prop (e.g. `<div class="column" style="--column-gap: var(--space-3)">`). |
| `spacing.css` | `.p/m × {x,y,t,r,b,l} × 11 token steps` (+ `auto` on margin axes). All reference `--space-*`. |
| `typography.css` | family/size/leading/tracking/align/transform/color atoms keyed to existing tokens in `theme/typography.css`. |
| `motion.css` | `.sr-only` (a11y standard) + `.motion-safe` (no-op under `prefers-reduced-motion: reduce`). |

## Why
PLAN §5 specifies utility-style primitives in the last cascade layer so they win over component CSS without specificity gymnastics. The layer was declared in `src/styles/index.css` but empty — atoms applied to a component instance had nothing to win against.

No existing call sites migrated; the goal is to make the layer available. Astro tree-shakes unused CSS, so home stays at **7.44KB / 12KB budget**.

## Test plan
- [x] `pnpm build:astro` — 32 pages built, no warnings
- [x] `node scripts/bundle-size.mjs` — within budget (CSS 7.44KB, JS 7.36KB)
- [ ] CI green