### PR TITLE
feat(home): add tools-shipped stat line

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -26,6 +26,8 @@
   "hero.bio": "Design systems & AI experiments @ Superhuman and Grammarly. Before: design systems at LinkedIn, conversational UI at Amazon.",
   "hero.statPending": "graph syncing soon · interactive grid mounts on scroll",
   "hero.statTemplate": "{total} contributions · {streak} streak · synced {synced}",
+  "hero.toolsStat": "{count} tools shipped",
+  "hero.toolsLinkText": "MCPs & Claude skills →",
   "home.metaDescription": "Frontend engineer. Design systems and AI tooling for designers.",
   "home.recentWorkEyebrow": "recent work",
   "home.recentWorkTitle": "Three case studies",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -26,6 +26,8 @@
   "hero.bio": "Sistemas de diseño y experimentos de IA en Superhuman y Grammarly. Antes: sistemas de diseño en LinkedIn, UI conversacional en Amazon.",
   "hero.statPending": "el grafo se sincroniza pronto · la cuadrícula interactiva carga al hacer scroll",
   "hero.statTemplate": "{total} contribuciones · {streak} días seguidos · sincronizado {synced}",
+  "hero.toolsStat": "{count} herramientas publicadas",
+  "hero.toolsLinkText": "MCPs y Claude skills →",
   "home.metaDescription": "Frontend engineer. Sistemas de diseño y herramientas de IA para diseñadores.",
   "home.recentWorkEyebrow": "trabajo reciente",
   "home.recentWorkTitle": "Tres casos de estudio",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,6 +63,15 @@ const statLine = stats && synced
       .replace("{streak}", String(stats.streak))
       .replace("{synced}", synced)
   : null;
+
+/*
+ * Tools-shipped count for the secondary stat line. Source of truth is the
+ * <dl class="colophon__tooling"> in src/pages/colophon.astro §9; update both
+ * when adding or removing a public tool repo. Kept as a literal to avoid
+ * pulling the colophon markup into a data module for a single integer.
+ */
+const toolsCount = 7;
+const toolsStat = t(locale, "hero.toolsStat").replace("{count}", String(toolsCount));
 ---
 
 <Base title="Luis Torres" description={t(locale, "home.metaDescription")}>
@@ -79,6 +88,12 @@ const statLine = stats && synced
         <p class="hero__stat">
           <span class="hero__stat-rule" aria-hidden="true">────</span>
           <span class="hero__stat-text">{statLine ?? t(locale, "hero.statPending")}</span>
+        </p>
+        <p class="hero__stat">
+          <span class="hero__stat-rule" aria-hidden="true">────</span>
+          <span class="hero__stat-text">
+            {toolsStat} · <a href={`${localePrefix(locale)}/colophon#ai-powered-tooling`}>{t(locale, "hero.toolsLinkText")}</a>
+          </span>
         </p>
       </div>
     </section>
@@ -181,6 +196,17 @@ const statLine = stats && synced
 
   .hero__stat-rule {
     color: var(--color-text-subtle);
+  }
+
+  .hero__stat a {
+    color: var(--color-action);
+    text-decoration: none;
+  }
+
+  .hero__stat a:hover,
+  .hero__stat a:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
   }
 
   /* Entrance — name, pitch, bio, stat-line fade up on a staggered cadence. */

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -200,13 +200,14 @@ const toolsStat = t(locale, "hero.toolsStat").replace("{count}", String(toolsCou
 
   .hero__stat a {
     color: var(--color-action);
-    text-decoration: none;
+    text-decoration: underline;
+    text-decoration-thickness: from-font;
+    text-underline-offset: 0.2em;
   }
 
   .hero__stat a:hover,
   .hero__stat a:focus-visible {
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
+    text-decoration-thickness: 0.1em;
   }
 
   /* Entrance — name, pitch, bio, stat-line fade up on a staggered cadence. */


### PR DESCRIPTION
## Summary
Adds a second mono stat line below the contribution stat:

```
──── 1,243 contributions · 12 streak · synced 2026-05-23
──── 7 tools shipped · MCPs & Claude skills →
```

The link deep-jumps into `/colophon#ai-powered-tooling`, the canonical list of Luis's public MCP/skill repos.

## Why
PLAN §8.5 calls for a quiet "tools shipped: N" stat alongside the contribution count so a Brand Web reviewer registers the AI-tooling JD bullet without having to scroll. Surfacing the count at the hero, with a link to the detailed colophon section, lands the signal without crowding.

## Notes
- i18n: `hero.toolsStat` + `hero.toolsLinkText` keys in both `en.json` and `es.json`. Locale-aware colophon link via `localePrefix(locale)`.
- The count (`7`) is a literal in `src/pages/index.astro` pointing at the colophon `<dl class="colophon__tooling">` as source of truth. Avoids pulling colophon markup into a data module for a single integer.
- Inherits the existing `.hero__stat` mono treatment and entrance stagger — both stat paragraphs fade up together at 280 ms.

## Test plan
- [x] `pnpm build:astro` — 32 pages built, no warnings
- [x] Both locales render: `/` shows "7 tools shipped" → `/colophon#ai-powered-tooling`; `/es` shows "7 herramientas publicadas" → `/es/colophon#ai-powered-tooling`
- [x] Bundle within budget (CSS 5.83KB / 12KB, JS 7.36KB / 8KB)
- [ ] CI green