### PR TITLE
feat(hero): use CSS if() + style() for layer color mapping

### DIFF
--- a/src/components/HeroName.astro
+++ b/src/components/HeroName.astro
@@ -84,15 +84,27 @@ const { name } = Astro.props;
     transition: translate var(--duration-slow) var(--ease-out-expo);
   }
 
-  /* :nth-child base layer — works everywhere. Multiplying terracotta + slate
-     onto the bone surface gives the small chromatic fringe; in dark mode
-     screening the inverted scale reproduces the same fringe direction. */
-  .hero-name > *:nth-child(1) { color: light-dark(var(--terracotta-60), var(--terracotta-40)); }
-  .hero-name > *:nth-child(2) { color: light-dark(var(--bone-80),       var(--bone-40)); }
-  .hero-name > *:nth-child(3) { color: light-dark(var(--slate-80),      var(--slate-40)); }
-
+  /* Modern primary — single declaration keyed off the layer index via the
+     CSS if() function + style() query. Each layer reads its own --index and
+     resolves to the matching token pair. Multiplying terracotta + slate over
+     bone gives the chromatic fringe; in dark mode the inverted scale screens
+     to reproduce the same fringe direction. */
   .hero-name > * {
+    color: if(
+      style(--index: 1): light-dark(var(--terracotta-60), var(--terracotta-40));
+      style(--index: 2): light-dark(var(--bone-80),       var(--bone-40));
+      else:              light-dark(var(--slate-80),      var(--slate-40))
+    );
     mix-blend-mode: multiply;
+  }
+
+  /* Fallback for browsers without if() / style() support — Firefox at time
+     of writing, and any Chromium / Safari older than the if() landing. The
+     :nth-child ladder is order-dependent but ships the identical palette. */
+  @supports not (color: if(style(--index: 1): red; else: blue)) {
+    .hero-name > *:nth-child(1) { color: light-dark(var(--terracotta-60), var(--terracotta-40)); }
+    .hero-name > *:nth-child(2) { color: light-dark(var(--bone-80),       var(--bone-40)); }
+    .hero-name > *:nth-child(3) { color: light-dark(var(--slate-80),      var(--slate-40)); }
   }
 
   /* Ambient pulse — set by the JS scheduler. */


### PR DESCRIPTION
## Summary
Replaces the `:nth-child` color ladder in HeroName with PLAN §7a's modern primary path: a single declaration that uses CSS `if()` + `style()` queries to read each layer's `--index` and resolve the matching token pair.

```css
/* Modern primary */
.hero-name > * {
  color: if(
    style(--index: 1): light-dark(var(--terracotta-60), var(--terracotta-40));
    style(--index: 2): light-dark(var(--bone-80),       var(--bone-40));
    else:              light-dark(var(--slate-80),      var(--slate-40))
  );
  mix-blend-mode: multiply;
}

/* Fallback — Firefox + older Chromium/Safari */
@supports not (color: if(style(--index: 1): red; else: blue)) {
  .hero-name > *:nth-child(1) { ... }
  .hero-name > *:nth-child(2) { ... }
  .hero-name > *:nth-child(3) { ... }
}
```

## Why
PLAN §7a specifies the `if()`/`style()` path as primary with `:nth-child` as the fallback. The current code shipped only the fallback — modern browsers were getting the order-dependent ladder rather than the declarative version. Both paths now coexist; same palette, browsers pick the one they support.

## Notes
- Palette identical across both paths — no visual change in any browser.
- `mix-blend-mode: multiply` retained intentionally per the comment-fixed dark-mode reasoning: dark-mode colors invert via `light-dark()`, so multiplying reproduces the same fringe direction without needing `light-dark(multiply, screen)`.
- Verified the `if()` syntax survives Vite/esbuild CSS minification — grep confirms both `if(style(...)` and `@supports not (color: if(...` are in the built CSS.
- Browser support: `if()` ships in Chrome 137+ and Safari 26+. Firefox still uses the `:nth-child` fallback.

## Test plan
- [x] `pnpm build:astro` — 32 pages, no warnings
- [x] Built CSS contains both `if(style(--index: 1)` and `@supports not (color: if`
- [x] Bundle within budget (CSS 5.88KB / 12KB)
- [ ] Visual QA: hero name renders identically in Chrome (modern path) and Firefox (fallback path) — light + dark
- [ ] CI green