### PR TITLE
refactor(base): move font-size from html to body

### DIFF
--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -2,7 +2,6 @@ html {
   background: var(--color-bg);
   color: var(--color-text-default);
   font-family: var(--font-body);
-  font-size: var(--type-16);
   line-height: var(--line-default);
   letter-spacing: var(--tracking-default);
   font-feature-settings: "ss01", "cv11";
@@ -13,6 +12,7 @@ body {
   min-height: 100svh;
   background: var(--color-bg);
   color: var(--color-text-default);
+  font-size: var(--type-16);
 }
 
 a {


### PR DESCRIPTION
## Summary
Moves `font-size: var(--type-16)` off the `html` element and onto `body`.

## Why
`html` sets the rem base — every rem-based value (spacing, `clamp()` type scale, container widths) computes relative to it. Setting `font-size` on `html` overrides the user's browser default. Two problems with that:

1. **Accessibility:** users who've cranked their browser's default font size (e.g. low-vision users on "Very Large" in Chrome settings) expect every rem on the page to scale proportionally. Setting `font-size` on `html` to a fixed value breaks that contract — our type scale stays the same regardless of their preference.
2. **Portability:** `html` declarations should ideally be limited to root-context concerns (color scheme, font family, line height). Body text size belongs on `body`.

`body` is the right home for the actual body font-size; `html` stays clean for inheritance + tap-highlight only.

## Test plan
- [x] `pnpm build:astro` — 32 pages, no warnings
- [x] Bundle within budget (CSS 5.82KB / 12KB)
- [ ] Visual QA: home / work / about / colophon render identically (the cascade gives `body` the same value the old `html` rule did)
- [ ] CI green