### PR TITLE
ci(sync): use PAT for actor so downstream workflows fire

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,15 +1,10 @@
 name: Deploy site to GitHub Pages
 
-# Triggers when master changes and (manually) from the Actions UI.
-# The pull_request: closed trigger covers the sync-contributions auto-merge
-# case: GitHub's loop-prevention rule swallows the `push` event when a commit
-# is authored by GITHUB_TOKEN (which is who performs the auto-merge squash),
-# so without this the sync would land on master but never deploy.
+# Triggers when master changes and (manually) from the Actions UI. The sync
+# workflow uses a PAT so its auto-merge fires the push trigger normally —
+# no need for a pull_request: closed listener.
 on:
   push:
-    branches: [master]
-  pull_request:
-    types: [closed]
     branches: [master]
   workflow_dispatch:
 
@@ -31,12 +26,6 @@ jobs:
   build:
     name: Build Astro
     runs-on: ubuntu-latest
-    # On pull_request events, only deploy when the PR actually merged. Skips
-    # closed-without-merge. The push trigger handles human merges that go via
-    # a non-GITHUB_TOKEN actor — the concurrency group dedups overlap.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.merged == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sync-contributions.yml
+++ b/.github/workflows/sync-contributions.yml
@@ -36,6 +36,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # PAT (yours, admin) rather than the default GITHUB_TOKEN so the
+          # subsequent push, PR open, and auto-merge are attributed to you.
+          # GitHub's loop-prevention rule swallows downstream workflow runs
+          # when those events come from GITHUB_TOKEN — meaning CI would never
+          # fire on the sync PR, required checks would never appear, and
+          # auto-merge would sit forever. Using your PAT routes around it.
+          token: ${{ secrets.SYNC_PAT }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -61,7 +69,9 @@ jobs:
 
       - name: Open auto-merging sync PR (if data changed)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # SYNC_PAT (not GITHUB_TOKEN) so gh commands run as you — same
+          # loop-prevention reasoning as the checkout step above.
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
PR #64 routed the sync workflow through a PR with auto-merge. First real run hit two walls of GitHub's loop-prevention rule:

1. **PRs opened by `GITHUB_TOKEN` don't trigger downstream workflows.** `ci.yml` never ran on the sync PR, so the 3 required checks never appeared, and auto-merge sat forever. (See PR #65 — open, waiting forever.)
2. **Pushes by `GITHUB_TOKEN` don't fire push triggers.** PR #64 worked around this with a `pull_request: closed` trigger on deploy-pages, but that runs against the PR ref — the `github-pages` environment branch policy locks deploys to `master` and rejected it. (Failed run: [26369019995](https://github.com/semanticpixel/theluistorres/actions/runs/26369019995).)

Both go away with one change: **use a PAT (yours, admin) instead of `GITHUB_TOKEN`** for the sync workflow's push + PR + auto-merge. PAT-driven events trigger downstream workflows normally:
- PAT opens PR → `ci.yml` fires → required checks satisfied
- Auto-merge fires the squash on PAT's behalf → push trigger on deploy-pages fires as usual

The `pull_request: closed` workaround on deploy-pages comes out of the workflow as part of this — push trigger handles everything cleanly.

## Requires
A new repository secret `SYNC_PAT` containing a fine-grained PAT scoped to this repo, with permissions:
- Contents: Read and write
- Pull requests: Read and write
- Workflows: Read and write (defensive — covers a future case where automation touches `.github/workflows/*`)

## What to do with PR #65
After this lands, manually close PR #65 (stuck-open, today's sync). The next sync run will create a fresh PR for the latest data.

Or merge #65 via admin bypass to land today's data now — your call.

## Test plan
- [ ] Create `SYNC_PAT` secret (see PAT creation instructions in the chat)
- [ ] Merge this PR
- [ ] Trigger sync-contributions manually via Actions UI
- [ ] Watch: PR opens → CI fires (this time) → auto-merges → push trigger fires deploy-pages → site rebuilds