### PR TITLE
chore(node): bump runtime to Node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/sync-contributions.yml
+++ b/.github/workflows/sync-contributions.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "packageManager": "pnpm@10.11.0",
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Bumps the project's Node requirement from 20 → 22 across CI workflows and `package.json` engines.

- Node 20 reached end-of-life in April 2026.
- GitHub is forcing JS-based actions to Node 24 by default starting June 2026.
- Astro 6 requires `>=22.12.0`; this PR is the prerequisite for that bump but ships standalone.

### Changes

- `.github/workflows/ci.yml`: three `setup-node@v4` pins → 22
- `.github/workflows/deploy-pages.yml`: 20 → 22
- `.github/workflows/sync-contributions.yml`: 20 → 22
- `package.json`: `engines.node` `>=20.0.0` → `>=22.0.0`

No lockfile change — we're still on Astro 5; the dep tree is untouched.

## Test plan

- [ ] CI green on this PR (typecheck · build · bundle budget, a11y, Lighthouse)
- [ ] Local `pnpm typecheck && pnpm build` succeeds (verified on Node 22.14)
- [ ] After merge, follow-up PR for Astro 6 (#63 / its successor) reaches further into its pipeline