### PR TITLE
chore(content): clear astro 6 zod deprecation hints

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
+import { z } from "astro/zod";
 
 /*
  * Content collections.
@@ -46,7 +47,7 @@ const writing = defineCollection({
     title: z.string().min(1),
     slug: z.string().regex(/^[a-z0-9-]+$/).optional(),
     summary: z.string().min(1).max(280),
-    externalUrl: z.string().url(),
+    externalUrl: z.url(),
     date: z.coerce.date(),
     readingTime: z.string().optional(),
     tags: z.array(z.string().min(1)).default([]),


### PR DESCRIPTION
## Summary

Clears the 24 `ts(6385)` deprecation hints that landed with the Astro 6 upgrade (#79). All in `src/content.config.ts`; nothing else uses `z` from `astro:content`.

### Changes

- **`z` import** — moved from `astro:content` to `astro/zod`. The re-export from `astro:content` is deprecated in Astro 6 and gets removed in Astro 7.
- **`z.string().url()` → `z.url()`** — the chained form was deprecated in zod 3.25+ in favor of the top-level constructor.

### Diff in numbers

| | Before | After |
|---|---|---|
| errors | 0 | 0 |
| warnings | 0 | 0 |
| hints | 24 | 0 |

## Test plan

- [ ] `pnpm typecheck` — 0/0/0 (verified locally)
- [ ] `pnpm build` — 34 pages, no regressions (verified locally)
- [ ] CI green