### PR TITLE
chore(ci): bump action versions and node-version 22 → 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,20 +17,20 @@ jobs:
     name: typecheck · build · bundle budget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         # Read the version from package.json's `packageManager` field. Specifying
-        # `version:` here in addition to that field makes pnpm/action-setup@v4
+        # `version:` here in addition to that field makes pnpm/action-setup@v6
         # bail with ERR_PNPM_BAD_PM_VERSION, even when the two values match —
         # see https://github.com/pnpm/action-setup#version. The other two
         # workflows (deploy-pages.yml, sync-contributions.yml) already rely on
         # packageManager as the single source of truth; this brings ci.yml in
         # line.
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -50,7 +50,7 @@ jobs:
         run: node scripts/bundle-size.mjs
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -62,14 +62,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -87,20 +87,20 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload a11y evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: a11y-evidence
           path: tmp/a11y/

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         # Reads packageManager + pnpm-workspace.yaml from the repo — no version
         # pinned here so the deploy follows what `package.json` declares.
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/sync-contributions.yml
+++ b/.github/workflows/sync-contributions.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # PAT (yours, admin) rather than the default GITHUB_TOKEN so the
           # subsequent push, PR open, and auto-merge are attributed to you.
@@ -46,12 +46,12 @@ jobs:
           token: ${{ secrets.SYNC_PAT }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Silences GitHub's Node 20 action-runtime deprecation (forced to Node 24 starting June 2026) and matches our build's `node-version` to that same major.

### Action version bumps (the three flagged in the deprecation)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `pnpm/action-setup` | v4 | v6 |

### Artifact actions (also v4 → newer Node runtime)

| Action | Before | After |
|---|---|---|
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |

### Build runtime

`node-version: 22` → `24` across all three workflows (ci, deploy-pages, sync-contributions).

### Deliberately left alone

- `engines.node` stays at `>=22.12.0`. That's Astro 6's functional floor — tightening it doesn't enable anything, just locks people out of Node 22.x.
- `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4` weren't flagged in the deprecation; bumping them would be unrelated scope.

## Local verification

- `pnpm typecheck` — 0/0/0
- `pnpm build` — 34 pages built clean

(Local Node is 22.14; the actual Node 24 build environment gets exercised in CI.)

## Risk notes

This bumps several action majors at once. If CI surfaces a regression, the likeliest culprits in order of suspicion:

1. **`actions/upload-artifact@v7` / `actions/download-artifact@v8`** — these have had behavioral changes around artifact immutability and pagination. Our usage is simple (`name + path`), so should be fine.
2. **`actions/checkout@v6`** — defaults around sparse-checkout / token persistence sometimes shift. Our usage is again basic.
3. **`pnpm/action-setup@v6`** — reads `packageManager` from `package.json`; unchanged from how we use it today.

If something breaks in a single action, narrowing it down is a one-line revert.

## Test plan

- [ ] CI green on this PR (all three jobs: typecheck/build, a11y, Lighthouse)
- [ ] `sync-contributions` workflow exercises tomorrow morning's cron without issue
- [ ] `deploy-pages` fires cleanly on merge to master