### PR TITLE
ci(sync): warn on stale work snapshot, report sync failures

### DIFF
--- a/.github/workflows/sync-contributions.yml
+++ b/.github/workflows/sync-contributions.yml
@@ -28,6 +28,7 @@ concurrency:
 permissions:
   contents: write        # push the sync branch
   pull-requests: write   # open / close PRs, enable auto-merge
+  issues: write          # file the failure / stale-data notifications below
 
 jobs:
   sync:
@@ -58,6 +59,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Fetch contributions
+        id: fetch
         env:
           # Only the personal token runs in CI. Work contributions come
           # from a committed snapshot at public/data/work-contributions.json,
@@ -107,3 +109,82 @@ jobs:
 
           # Auto-merge waits for the 3 required CI checks to pass, then squashes.
           gh pr merge "$branch" --auto --squash
+
+      # The work snapshot is hand-committed, so it drifts. Stale data doesn't
+      # fail anything — it just silently under-reports the graph (see the
+      # rationale in scripts/fetch-contributions.mjs). The script emits the
+      # lag; this turns it into something you'll actually see.
+      - name: Flag stale work snapshot
+        if: steps.fetch.outputs.work_snapshot_stale == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+          NEWEST: ${{ steps.fetch.outputs.work_snapshot_newest }}
+          LAG: ${{ steps.fetch.outputs.work_snapshot_lag_days }}
+        run: |
+          set -euo pipefail
+          gh label create sync-stale-data --color fbca04 \
+            --description "Work contributions snapshot has drifted out of date" --force
+
+          # Quiet if one is already open: the issue's existence is the signal.
+          # This runs nightly, so commenting on every run would produce the
+          # same wall of noise that made the last outage easy to ignore.
+          if [[ -n "$(gh issue list --label sync-stale-data --state open --limit 1 --json number --jq '.[].number')" ]]; then
+            echo "Stale-data issue already open — staying quiet."
+            exit 0
+          fi
+
+          # Heredoc to a file, not "$(cat <<EOF ...)". Inside a command
+          # substitution bash scans ahead for the closing paren and treats an
+          # apostrophe in the prose as an opening quote — a stray "doesn't"
+          # is a syntax error that only fires on the day this step is needed.
+          cat > "${RUNNER_TEMP:-/tmp}/stale-body.md" <<EOF
+          \`public/data/work-contributions.json\` only reaches **${NEWEST}** — ${LAG} days behind.
+
+          Work contributions after that date are missing from the contribution graph. They render as empty days, which is indistinguishable from days with no work, so the graph under-reports real activity until this is refreshed.
+
+          **Fix:** run \`node scripts/fetch-work-contributions.mjs\` locally (it needs your logged-in \`gh\` session) and commit the updated file. The next sync picks it up.
+
+          Closing this issue is safe once the snapshot is refreshed; a new one opens if it drifts again.
+          EOF
+
+          gh issue create \
+            --title "Work contributions snapshot is stale (${LAG} days behind)" \
+            --label sync-stale-data \
+            --body-file "${RUNNER_TEMP:-/tmp}/stale-body.md"
+
+      # This workflow failed silently for 31 consecutive nights in June/July
+      # 2026 (an expired PAT) because nothing reported a red scheduled run.
+      # Scheduled workflows have no PR to annotate, so failure has to be pushed
+      # somewhere visible or it isn't noticed at all.
+      - name: Report sync failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh label create sync-failure --color d73a4a \
+            --description "Nightly contributions sync is failing" --force
+
+          # Same quiet-if-open rule as above: one issue per outage, not per night.
+          if [[ -n "$(gh issue list --label sync-failure --state open --limit 1 --json number --jq '.[].number')" ]]; then
+            echo "Failure issue already open — staying quiet."
+            exit 0
+          fi
+
+          # See the note in the stale-snapshot step: heredoc to a file rather
+          # than through a command substitution, so prose can contain quotes.
+          cat > "${RUNNER_TEMP:-/tmp}/failure-body.md" <<EOF
+          The scheduled contributions sync failed: [run ${GITHUB_RUN_ID}](${RUN_URL})
+
+          The graph is frozen at its last good sync until this is fixed. Nothing else surfaces this — the workflow only runs on a schedule, so a red run is invisible unless you go looking.
+
+          **Common cause:** an expired \`PERSONAL_GH_TOKEN\` (\`HTTP 401: Bad credentials\` in the fetch step). Mint a new classic PAT with \`read:user\` and update the secret. Note that \`gh secret set\` needs a real terminal — it reads the value from stdin and will silently store an empty string if there is no TTY to prompt, which looks identical to success.
+
+          This issue stays open (and silent) until closed; a new one opens on the next failure after that.
+          EOF
+
+          gh issue create \
+            --title "Nightly contributions sync is failing" \
+            --label sync-failure \
+            --body-file "${RUNNER_TEMP:-/tmp}/failure-body.md"

--- a/scripts/fetch-contributions.mjs
+++ b/scripts/fetch-contributions.mjs
@@ -23,7 +23,7 @@
  * just `fetch`. Smaller surface, easier to read, easier to debug in CI logs.
  */
 
-import { writeFile, mkdir, readFile, stat } from "node:fs/promises";
+import { writeFile, mkdir, readFile, stat, appendFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -193,6 +193,36 @@ async function readWorkSnapshot() {
   }
 }
 
+/*
+ * The work snapshot is committed by hand, so it drifts between local runs of
+ * fetch-work-contributions.mjs. Drift is invisible in the output: days the
+ * snapshot doesn't reach sum in zero work contributions, which renders
+ * identically to a day with no work. The graph quietly under-reports and
+ * nothing complains — in July 2026 a 5-week-stale snapshot hid ~1900 real
+ * contributions and made a worked month look idle.
+ *
+ * Warn rather than throw. The personal half of the sync is still worth
+ * writing, and hard-failing over a file that's *expected* to lag a few days
+ * would freeze the whole graph to protect it from being slightly behind.
+ * The annotation shows on the run summary; the workflow escalates to an issue.
+ */
+const STALE_AFTER_DAYS = Number(process.env.WORK_SNAPSHOT_STALE_AFTER_DAYS ?? 14);
+
+function checkWorkFreshness(snapshot, todayISO) {
+  const dates = snapshot.contributions.map(d => d.date).sort();
+  const newest = snapshot.range?.to?.slice(0, 10) ?? dates[dates.length - 1];
+  if (!newest) return null;
+  const lagDays = Math.floor((Date.parse(todayISO) - Date.parse(newest)) / 86_400_000);
+  return { newest, lagDays, stale: lagDays > STALE_AFTER_DAYS };
+}
+
+/* Hand results to later workflow steps; no-op outside Actions. */
+async function emitOutputs(pairs) {
+  if (!process.env.GITHUB_OUTPUT) return;
+  const lines = Object.entries(pairs).map(([k, v]) => `${k}=${v}\n`).join("");
+  await appendFile(process.env.GITHUB_OUTPUT, lines);
+}
+
 const { from, to } = range();
 
 const personal = await fetchCalendar({
@@ -206,7 +236,16 @@ let total = personal.totalContributions;
 
 const workSnapshot = await readWorkSnapshot();
 const sources = ["personal"];
+let freshness = null;
 if (workSnapshot) {
+  freshness = checkWorkFreshness(workSnapshot, to.slice(0, 10));
+  if (freshness?.stale) {
+    console.log(
+      `::warning title=Work snapshot is stale::public/data/work-contributions.json only reaches ${freshness.newest} ` +
+        `(${freshness.lagDays} days behind). Work contributions after that date are missing from the graph. ` +
+        `Re-run scripts/fetch-work-contributions.mjs locally and commit the result.`,
+    );
+  }
   const workMap = new Map();
   for (const d of workSnapshot.contributions) {
     /* Drop days outside our sync window so the level percentile bucketing
@@ -245,3 +284,14 @@ await writeFile(resolve(dir, "contributions.json"), JSON.stringify(out, null, 2)
 console.log(
   `fetch-contributions: ${days.length} days · ${total} total · ${streak}-day streak · today ${today?.count ?? 0} · sources=${sources.join("+")}`,
 );
+if (freshness) {
+  console.log(
+    `fetch-contributions: work snapshot reaches ${freshness.newest} (${freshness.lagDays}d behind, threshold ${STALE_AFTER_DAYS}d)`,
+  );
+}
+
+await emitOutputs({
+  work_snapshot_stale: String(freshness?.stale ?? false),
+  work_snapshot_newest: freshness?.newest ?? "",
+  work_snapshot_lag_days: String(freshness?.lagDays ?? ""),
+});


### PR DESCRIPTION
Two guardrails for the nightly contributions sync, prompted by tonight's outage.

## What happened

The sync failed **31 nights running** (Jun 14 – Jul 15) on an expired `PERSONAL_GH_TOKEN` — every run died with `HTTP 401: Bad credentials`. Nothing reported it. The workflow only runs on a schedule, so there's no PR to annotate, and a red scheduled run is invisible unless you go looking.

Underneath that, a second failure was hiding: `public/data/work-contributions.json` is committed by hand and had drifted 5 weeks stale (last updated Jun 10). Stale work data doesn't error — days the snapshot doesn't reach sum in zero work contributions and render *identically* to days with no work. The graph quietly under-reported ~1,900 real contributions and looked like an idle month.

Both failures were silent. That's the thing being fixed.

## Changes

**`scripts/fetch-contributions.mjs` — staleness guard**

Compares the work snapshot's reach against the sync date and warns past a threshold (default 14d, overridable via `WORK_SNAPSHOT_STALE_AFTER_DAYS`). Emits a `::warning::` annotation plus step outputs for the workflow to escalate.

Warns rather than throws: the personal half of the sync is still worth writing, and hard-failing over a file that's *expected* to lag a few days would freeze the whole graph to protect it from being slightly behind. 14d is ~1.5× the usual commit cadence on that file (Jun 1 → Jun 10 was 9d), so it catches real drift without crying wolf.

**`.github/workflows/sync-contributions.yml` — notifications**

- `if: failure()` step files an issue with the run link and the 401 diagnosis.
- Stale-snapshot step files an issue when the guard trips.
- Adds `issues: write`.

Both dedupe on a label and stay quiet while an issue is already open — one issue per outage, not one per night. A notifier that produces 31 issues is as ignorable as one that produces none.

## Testing

Ran `fetch-contributions.mjs` against live data for all three paths:

| case | result |
|---|---|
| fresh snapshot, 14d threshold | no warning, `stale=false` |
| threshold forced to `-1` | `::warning::` fires, `stale=true` |
| no snapshot at all | no crash, personal-only sync still writes |

Both workflow steps were extracted, Actions-expressions substituted, syntax-checked, and executed with `gh` stubbed — verifying rendered issue bodies and the quiet-if-open dedupe path.

That testing caught a real bug: the first version built issue bodies with `"$(cat <<EOF ...)"`. Inside a command substitution bash scans ahead for the closing paren and reads the apostrophe in "there's" as an opening quote — valid YAML, valid-looking step, guaranteed syntax error that would only ever fire on the night the sync broke. Both steps now use `--body-file`, which is immune to prose.

## Note

Personal-only totals 1,004 contributions vs 14,263 with work merged — ~93% of the graph depends on that hand-committed snapshot. Its staleness is the highest-leverage silent failure in this pipeline.
